### PR TITLE
More robust CF datetime unit parsing

### DIFF
--- a/xray/conventions.py
+++ b/xray/conventions.py
@@ -71,6 +71,9 @@ def _netcdf_to_numpy_timeunit(units):
 
 
 def _unpack_netcdf_time_units(units):
+    # CF datetime units follow the format: "UNIT since DATE"
+    # this parses out the unit and date allowing for extraneous
+    # whitespace.
     matches = re.match('\s*(\S+)\s+since\s+(.+)\s*', units).groups()
     if not matches:
         raise ValueError('invalid time units: %s' % units)

--- a/xray/conventions.py
+++ b/xray/conventions.py
@@ -1,10 +1,9 @@
-import functools
-import numpy as np
-import pandas as pd
 import re
 import warnings
-from collections import defaultdict
+import numpy as np
+import pandas as pd
 from datetime import datetime
+from collections import defaultdict
 from pandas.tslib import OutOfBoundsDatetime
 
 from .core import indexing, utils
@@ -74,11 +73,11 @@ def _unpack_netcdf_time_units(units):
     # CF datetime units follow the format: "UNIT since DATE"
     # this parses out the unit and date allowing for extraneous
     # whitespace.
-    matches = re.match('\s*(\S+)\s+since\s+(.+)\s*', units).groups()
+    matches = re.match('(.+) since (.+)', units)
     if not matches:
         raise ValueError('invalid time units: %s' % units)
-    delta, ref_date = matches
-    return delta, ref_date
+    delta_units, ref_date = [s.strip() for s in matches.groups()]
+    return delta_units, ref_date
 
 
 def _decode_netcdf_datetime(num_dates, units, calendar):

--- a/xray/conventions.py
+++ b/xray/conventions.py
@@ -64,11 +64,14 @@ def mask_and_scale(array, fill_value=None, scale_factor=None, add_offset=None,
 
 
 def _netcdf_to_numpy_timeunit(units):
+    units = units.lower()
+    if not units.endswith('s'):
+        units = '%ss' % units
     return {'seconds': 's', 'minutes': 'm', 'hours': 'h', 'days': 'D'}[units]
 
 
 def _unpack_netcdf_time_units(units):
-    matches = re.match('(\S+) since (.+)', units).groups()
+    matches = re.match('\s*(\S+)\s+since\s+(.+)\s*', units).groups()
     if not matches:
         raise ValueError('invalid time units: %s' % units)
     delta, ref_date = matches
@@ -110,7 +113,6 @@ def decode_cf_datetime(num_dates, units, calendar=None):
     """
     num_dates = np.asarray(num_dates, dtype=float)
     flat_num_dates = num_dates.ravel()
-    orig_shape = num_dates.shape
     if calendar is None:
         calendar = 'standard'
 
@@ -139,6 +141,7 @@ def decode_cf_timedelta(num_timedeltas, units):
 
 
 TIME_UNITS = set(['days', 'hours', 'minutes', 'seconds'])
+
 
 def _infer_time_units_from_diff(unique_timedeltas):
     for time_unit, delta in [('days', 86400), ('hours', 3600),

--- a/xray/test/test_conventions.py
+++ b/xray/test/test_conventions.py
@@ -102,8 +102,13 @@ class TestDatetime(TestCase):
                 (np.arange(100), 'days since 2000-01-01'),
                 (np.arange(100).reshape(10, 10), 'days since 2000-01-01'),
                 (12300 + np.arange(50), 'hours since 1680-01-01 00:00:00'),
+                # here we add a couple minor formatting errors to test
+                # the robustness of the parsing algorithm.
+                (12300 + np.arange(50), 'hour since 1680-01-01  00:00:00'),
+                (12300 + np.arange(50), 'Hour  since 1680-01-01 00:00:00'),
+                (12300 + np.arange(50), ' Hour  since  1680-01-01 00:00:00 '),
                 (10, 'days since 2000-01-01'),
-                ([10], 'days since 2000-01-01'),
+                ([10], 'daYs  since 2000-01-01'),
                 ([[10]], 'days since 2000-01-01'),
                 ([10, 10], 'days since 2000-01-01'),
                 (0, 'days since 1000-01-01'),

--- a/xray/test/test_conventions.py
+++ b/xray/test/test_conventions.py
@@ -105,7 +105,7 @@ class TestDatetime(TestCase):
                 # here we add a couple minor formatting errors to test
                 # the robustness of the parsing algorithm.
                 (12300 + np.arange(50), 'hour since 1680-01-01  00:00:00'),
-                (12300 + np.arange(50), 'Hour  since 1680-01-01 00:00:00'),
+                (12300 + np.arange(50), u'Hour  since 1680-01-01 00:00:00'),
                 (12300 + np.arange(50), ' Hour  since  1680-01-01 00:00:00 '),
                 (10, 'days since 2000-01-01'),
                 ([10], 'daYs  since 2000-01-01'),


### PR DESCRIPTION
This makes it possible to read datasets that don't follow CF datetime conventions perfectly, such as the following example which (surprisingly) comes from NCEP/NCAR (you'd think they would follow CF!)
```
ds = xray.open_dataset('http://thredds.ucar.edu/thredds/dodsC/grib/NCEP/GEFS/Global_1p0deg_Ensemble/members/GEFS_Global_1p0deg_Ensemble_20150114_1200.grib2/GC')
print ds['time'].encoding['units']

u'Hour since 2015-01-14T12:00:00Z'
```
