### PR TITLE
Automatic label-based alignment for math and Dataset constructor

### DIFF
--- a/doc/whats-new.rst
+++ b/doc/whats-new.rst
@@ -12,10 +12,13 @@ What's New
 v0.4 (unreleased)
 -----------------
 
-.. These need tests:
-.. ``Dataset.update`` no longer updates attributes as well as variables.
-.. ``Dataset.__init__`` is not longer as strict by default
-.. TODO: auto-align Dataset arithmetic
+Highlights
+~~~~~~~~~~
+
+- Automatic alignment of index labels in arithmetic, dataset cosntruction and
+  merging.
+- Aggregation operations skip missing values by default.
+- Lots of bug fixes.
 
 v0.3.2 (23 December, 2014)
 --------------------------

--- a/doc/whats-new.rst
+++ b/doc/whats-new.rst
@@ -9,6 +9,14 @@ What's New
     import xray
     np.random.seed(123456)
 
+v0.4 (unreleased)
+-----------------
+
+.. These need tests:
+.. ``Dataset.update`` no longer updates attributes as well as variables.
+.. ``Dataset.__init__`` is not longer as strict by default
+.. TODO: auto-align Dataset arithmetic
+
 v0.3.2 (23 December, 2014)
 --------------------------
 

--- a/xray/core/alignment.py
+++ b/xray/core/alignment.py
@@ -27,8 +27,7 @@ def align(*objects, **kwargs):
     objects with aligned indexes.
 
     Array from the aligned objects are suitable as input to mathematical
-    operators, because along each dimension they are indexed by the same
-    indexes.
+    operators, because along each dimension they have the same indexes.
 
     Missing values (if ``join != 'inner'``) are filled with NaN.
 
@@ -44,8 +43,8 @@ def align(*objects, **kwargs):
          - 'left': use indexes from the first object with each dimension
          - 'right': use indexes from the last object with each dimension
     copy : bool, optional
-        If `copy=True`, the returned objects contain all new variables. If
-        `copy=False` and no reindexing is required then the aligned objects
+        If ``copy=True``, the returned objects contain all new variables. If
+        ``copy=False`` and no reindexing is required then the aligned objects
         will include original variables.
 
     Returns
@@ -55,6 +54,9 @@ def align(*objects, **kwargs):
     """
     join = kwargs.pop('join', 'inner')
     copy = kwargs.pop('copy', True)
+    if kwargs:
+        raise TypeError('align() got unexpected keyword arguments: %s'
+                        % list(kwargs))
 
     if join == 'outer':
         join_indices = functools.partial(functools.reduce, operator.or_)

--- a/xray/core/alignment.py
+++ b/xray/core/alignment.py
@@ -12,12 +12,37 @@ from .utils import is_full_slice
 from .variable import as_variable, Variable, Coordinate, broadcast_variables
 
 
-def _get_all_indexes(objects):
+def _get_joiner(join):
+    if join == 'outer':
+        return functools.partial(functools.reduce, operator.or_)
+    elif join == 'inner':
+        return functools.partial(functools.reduce, operator.and_)
+    elif join == 'left':
+        return operator.itemgetter(0)
+    elif join == 'right':
+        return operator.itemgetter(-1)
+    else:
+        raise ValueError('invalid value for join: %s' % join)
+
+
+def _get_all_indexes(objects, exclude=set()):
     all_indexes = defaultdict(list)
     for obj in objects:
         for k, v in iteritems(obj.indexes):
-            all_indexes[k].append(v)
+            if k not in exclude:
+                all_indexes[k].append(v)
     return all_indexes
+
+
+def _join_indexes(join, objects, exclude=set()):
+    joiner = _get_joiner(join)
+    indexes = _get_all_indexes(objects, exclude=exclude)
+    # exclude dimensions with all equal indices (the usual case) to avoid
+    # unnecessary reindexing work.
+    # TODO: don't bother to check equals for left or right joins
+    joined_indexes = dict((k, joiner(v)) for k, v in iteritems(indexes)
+                          if any(not v[0].equals(idx) for idx in v[1:]))
+    return joined_indexes
 
 
 def align(*objects, **kwargs):
@@ -38,10 +63,10 @@ def align(*objects, **kwargs):
     join : {'outer', 'inner', 'left', 'right'}, optional
         Method for joining the indexes of the passed objects along each
         dimension:
-         - 'outer': use the union of object indexes
-         - 'inner': use the intersection of object indexes
-         - 'left': use indexes from the first object with each dimension
-         - 'right': use indexes from the last object with each dimension
+        - 'outer': use the union of object indexes
+        - 'inner': use the intersection of object indexes
+        - 'left': use indexes from the first object with each dimension
+        - 'right': use indexes from the last object with each dimension
     copy : bool, optional
         If ``copy=True``, the returned objects contain all new variables. If
         ``copy=False`` and no reindexing is required then the aligned objects
@@ -58,22 +83,23 @@ def align(*objects, **kwargs):
         raise TypeError('align() got unexpected keyword arguments: %s'
                         % list(kwargs))
 
-    if join == 'outer':
-        join_indices = functools.partial(functools.reduce, operator.or_)
-    elif join == 'inner':
-        join_indices = functools.partial(functools.reduce, operator.and_)
-    elif join == 'left':
-        join_indices = operator.itemgetter(0)
-    elif join == 'right':
-        join_indices = operator.itemgetter(-1)
+    joined_indexes = _join_indexes(join, objects)
+    return tuple(obj.reindex(copy=copy, **joined_indexes) for obj in objects)
 
-    all_indexes = _get_all_indexes(objects)
 
-    # Exclude dimensions with all equal indices to avoid unnecessary reindexing
-    # work.
-    joined_indexes = dict((k, join_indices(v)) for k, v in iteritems(all_indexes)
-                          if any(not v[0].equals(idx) for idx in v[1:]))
+def partial_align(*objects, **kwargs):
+    """partial_align(*objects, join='inner', copy=True, exclude=set()
 
+    Like align, but don't align along dimensions in exclude. Not public API.
+    """
+    join = kwargs.pop('join', 'inner')
+    copy = kwargs.pop('copy', True)
+    exclude = kwargs.pop('exclude', set())
+    if kwargs:
+        raise TypeError('align() got unexpected keyword arguments: %s'
+                        % list(kwargs))
+
+    joined_indexes = _join_indexes(join, objects, exclude=exclude)
     return tuple(obj.reindex(copy=copy, **joined_indexes) for obj in objects)
 
 

--- a/xray/core/dataarray.py
+++ b/xray/core/dataarray.py
@@ -9,6 +9,7 @@ from . import groupby
 from . import ops
 from . import utils
 from . import variable
+from .alignment import align
 from .common import AbstractArray, AttrAccessMixin
 from .coordinates import DataArrayCoordinates, Indexes
 from .dataset import Dataset
@@ -950,6 +951,13 @@ class DataArray(AbstractArray, AttrAccessMixin):
         def func(self, other):
             if isinstance(other, (Dataset, groupby.GroupBy)):
                 return NotImplemented
+            if hasattr(other, 'indexes'):
+                self, other = align(self, other, join='inner', copy=False)
+                empty_indexes = [d for d, s in zip(self.dims, self.shape)
+                                 if s == 0]
+                if empty_indexes:
+                    raise ValueError('no overlapping labels for some '
+                                     'dimensions: %s' % empty_indexes)
             other_coords = getattr(other, 'coords', None)
             other_variable = getattr(other, 'variable', other)
             ds = self.coords.merge(other_coords)

--- a/xray/test/test_dataset.py
+++ b/xray/test/test_dataset.py
@@ -1595,6 +1595,19 @@ class TestDataset(TestCase):
         with self.assertRaisesRegexp(ValueError, 'no overlapping labels'):
             ds.isel(x=slice(1)) + ds.isel(x=slice(1, None))
 
+        actual = ds + ds[['bar']]
+        expected = (2 * ds[['bar']]).merge(ds.coords)
+        self.assertDatasetIdentical(expected, actual)
+
+        with self.assertRaisesRegexp(ValueError, 'no overlapping variables'):
+            ds + Dataset()
+
+        with self.assertRaisesRegexp(ValueError, 'no overlapping variables'):
+            Dataset() + Dataset()
+
+        # maybe unary arithmetic with empty datasets should raise instead?
+        self.assertDatasetIdentical(Dataset() + 1, Dataset())
+
     def test_dataset_math_errors(self):
         ds = self.make_example_math_dataset()
 
@@ -1602,8 +1615,8 @@ class TestDataset(TestCase):
             ds['foo'] += ds
         with self.assertRaises(TypeError):
             ds['foo'].variable += ds
-        with self.assertRaisesRegexp(ValueError, 'do not have the same'):
-            ds + ds[['bar']]
+        with self.assertRaisesRegexp(ValueError, 'must have the same'):
+            ds += ds[['bar']]
 
         # verify we can rollback in-place operations if something goes wrong
         # nb. inplace datetime64 math actually will work with an integer array

--- a/xray/test/test_dataset.py
+++ b/xray/test/test_dataset.py
@@ -1481,6 +1481,21 @@ class TestDataset(TestCase):
 
         self.assertDatasetIdentical(ds == ds, ds.notnull())
 
+        subsampled = ds.isel(y=slice(2))
+        expected = 2 * subsampled
+        self.assertDatasetIdentical(expected, subsampled + ds)
+        self.assertDatasetIdentical(expected, ds + subsampled)
+
+    def test_dataset_math_automatic_alignment(self):
+        ds = self.make_example_math_dataset()
+        subset = ds.isel(x=slice(2), y=[1, 3])
+        expected = 2 * subset
+        actual = ds + subset
+        self.assertDatasetIdentical(expected, actual)
+
+        with self.assertRaisesRegexp(ValueError, 'no overlapping labels'):
+            ds.isel(x=slice(1)) + ds.isel(x=slice(1, None))
+
     def test_dataset_math_errors(self):
         ds = self.make_example_math_dataset()
 


### PR DESCRIPTION
Fixes #186.

This will be a major breaking change for v0.4. For example, we can now do things like this:
```
In [5]: x = xray.DataArray(range(5), dims='x')

In [6]: x
Out[6]:
<xray.DataArray (x: 5)>
array([0, 1, 2, 3, 4])
Coordinates:
  * x        (x) int64 0 1 2 3 4

In [7]: x[:4] + x[1:]
Out[7]:
<xray.DataArray (x: 3)>
array([2, 4, 6])
Coordinates:
  * x        (x) int64 1 2 3
```
