### PR TITLE
Update time.season to use text labels like 'DJF'

### DIFF
--- a/doc/whats-new.rst
+++ b/doc/whats-new.rst
@@ -71,8 +71,16 @@ Breaking changes
 - You will need to update your code if you have been ignoring deprecation
   warnings: methods and attributes that were deprecated in xray v0.3 or earlier
   (e.g., ``dimensions``, ``attributes```) have gone away.
-- TODO: season to use text labels. ``broadcast_equals`` method? ``drop``
-  method?
+- The ``season`` datetime shortcut now returns an array of string labels
+  such `'DJF'`:
+
+  .. ipython:: python
+
+      ds = Dataset({'t': pd.date_range('2000-01-01', periods=12, freq='M')})
+      ds['t.season']
+
+  Previously, it returned numbered seasons 1 through 4.
+- TODO: ``broadcast_equals`` method? ``drop`` method?
 
 .. _bottleneck: https://github.com/kwgoodman/bottleneck
 

--- a/xray/core/dataset.py
+++ b/xray/core/dataset.py
@@ -147,9 +147,10 @@ def _get_virtual_variable(variables, key):
         raise KeyError(key)
 
     if suffix == 'season':
-        # seasons = np.array(['DJF', 'MAM', 'JJA', 'SON'])
+        # TODO: move 'season' into pandas itself
+        seasons = np.array(['DJF', 'MAM', 'JJA', 'SON'])
         month = date.month
-        data = (month // 3) % 4 + 1
+        data = seasons[(month // 3) % 4]
     else:
         data = getattr(date, suffix)
     return ref_var_name, variable.Variable(ref_var.dims, data)

--- a/xray/test/test_dataset.py
+++ b/xray/test/test_dataset.py
@@ -915,7 +915,7 @@ class TestDataset(TestCase):
                                  Variable('time', 1 + np.arange(20)))
         self.assertArrayEqual(data['time.month'].values,
                               data.variables['time'].to_index().month)
-        self.assertArrayEqual(data['time.season'].values, 1)
+        self.assertArrayEqual(data['time.season'].values, 'DJF')
         # test virtual variable math
         self.assertArrayEqual(data['time.dayofyear'] + 1, 2 + np.arange(20))
         self.assertArrayEqual(np.sin(data['time.dayofyear']),
@@ -927,6 +927,11 @@ class TestDataset(TestCase):
         # non-coordinate variables
         ds = Dataset({'t': ('x', pd.date_range('2000-01-01', periods=3))})
         self.assertTrue((ds['t.year'] == 2000).all())
+
+    def test_time_season(self):
+        ds = Dataset({'t': pd.date_range('2000-01-01', periods=12, freq='M')})
+        expected = ['DJF'] * 2 + ['MAM'] * 3 + ['JJA'] * 3 + ['SON'] * 3 + ['DJF']
+        self.assertArrayEqual(expected, ds['t.season'])
 
     def test_slice_virtual_variable(self):
         data = create_test_data()


### PR DESCRIPTION
Previously, I used numbers 1 through 4 for the sake of consistency with
pandas, but such labels really were impossible to keep track of.