### PR TITLE
Unify netCDF4 and scipy backends in the public API

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,6 +17,7 @@ matrix:
     # https://github.com/ContinuumIO/anaconda-issues/issues/145
     env: UPDATE_ENV="conda remove scipy netCDF4"
   - python: 3.3
+    env: UPDATE_ENV="conda remove netCDF4"
   - python: 3.4
     env: UPDATE_ENV="pip install cyordereddict && conda install -c pandas bottleneck"
   # don't require pydap tests to pass because the dap test server is unreliable

--- a/doc/whats-new.rst
+++ b/doc/whats-new.rst
@@ -91,6 +91,11 @@ Enhancements
   pandas 0.16, which will support ``method='nearest'``.
 - Use functions that return generic ndarrays with DataArray.groupby.apply and
   Dataset.apply (:issue:`327` and :issue:`329`). Thanks Jeff Gerard!
+- Consolidated the functionality of `dumps` (writing a dataset to a netCDF file
+  as a bytestring) into the `to_netcdf` method (:issue:`333`).
+- `to_netcdf` now supports writing to groups in netCDF4 files (:issue:`333`).
+- `to_netcdf` now works when netcdf4-python is not installed as long as scipy
+  is available (:issue:`333`).
 - TODO: added a documentation example by Joe Hamman.
 
 Bug fixes

--- a/xray/backends/netCDF4_.py
+++ b/xray/backends/netCDF4_.py
@@ -54,7 +54,7 @@ def _nc4_values_and_dtype(var):
     return var, dtype
 
 
-def _nc4_group(ds, group):
+def _nc4_group(ds, group, mode):
     if group in set([None, '', '/']):
         # use the root group
         return ds
@@ -68,8 +68,11 @@ def _nc4_group(ds, group):
             try:
                 ds = ds.groups[key]
             except KeyError as e:
-                # wrap error to provide slightly more helpful message
-                raise IOError('group not found: %s' % key, e)
+                if mode != 'r':
+                    ds = ds.createGroup(key)
+                else:
+                    # wrap error to provide slightly more helpful message
+                    raise IOError('group not found: %s' % key, e)
         return ds
 
 
@@ -91,7 +94,7 @@ class NetCDF4DataStore(AbstractWritableDataStore):
         ds = nc4.Dataset(filename, mode=mode, clobber=clobber,
                          diskless=diskless, persist=persist,
                          format=format)
-        self.ds = _nc4_group(ds, group)
+        self.ds = _nc4_group(ds, group, mode)
         self.format = format
         self._filename = filename
 

--- a/xray/conventions.py
+++ b/xray/conventions.py
@@ -83,7 +83,7 @@ def _unpack_netcdf_time_units(units):
     return delta_units, ref_date
 
 
-def _decode_netcdf_datetime(num_dates, units, calendar):
+def _decode_datetime_with_netcdf4(num_dates, units, calendar):
     import netCDF4 as nc4
 
     dates = np.asarray(nc4.num2date(num_dates, units, calendar))
@@ -134,7 +134,7 @@ def decode_cf_datetime(num_dates, units, calendar=None):
     # ValueError is raised by pd.Timestamp for non-ISO timestamp strings,
     # in which case we fall back to using netCDF4
     except (OutOfBoundsDatetime, ValueError, OverflowError):
-        dates = _decode_netcdf_datetime(flat_num_dates, units, calendar)
+        dates = _decode_datetime_with_netcdf4(flat_num_dates, units, calendar)
 
     return dates.reshape(num_dates.shape)
 
@@ -203,6 +203,24 @@ def _cleanup_netcdf_time_units(units):
     return units
 
 
+def _encode_datetime_with_netcdf4(dates, units, calendar):
+    """Fallback method for encoding dates using netCDF4-python.
+
+    This method is more flexible than xray's parsing using datetime64[ns]
+    arrays but also slower because it loops over each element.
+    """
+    import netCDF4 as nc4
+
+    if np.issubdtype(dates.dtype, np.datetime64):
+        # numpy's broken datetime conversion only works for us precision
+        dates = dates.astype('M8[us]').astype(datetime)
+
+    def encode_datetime(d):
+        return np.nan if d is None else nc4.date2num(d, units, calendar)
+
+    return np.vectorize(encode_datetime)(dates)
+
+
 def encode_cf_datetime(dates, units=None, calendar=None):
     """Given an array of datetime objects, returns the tuple `(num, units,
     calendar)` suitable for a CF complient time variable.
@@ -228,6 +246,7 @@ def encode_cf_datetime(dates, units=None, calendar=None):
     delta, ref_date = _unpack_netcdf_time_units(units)
     try:
         if calendar not in _STANDARD_CALENDARS or dates.dtype.kind == 'O':
+            # parse with netCDF4 instead
             raise OutOfBoundsDatetime
         assert dates.dtype == 'datetime64[ns]'
 
@@ -237,16 +256,8 @@ def encode_cf_datetime(dates, units=None, calendar=None):
         num = (dates - ref_date) / time_delta
 
     except (OutOfBoundsDatetime, ValueError, OverflowError):
-        import netCDF4 as nc4
+        num = _encode_datetime_with_netcdf4(dates, units, calendar)
 
-        if np.issubdtype(dates.dtype, np.datetime64):
-            # numpy's broken datetime conversion only works for us precision
-            dates = dates.astype('M8[us]').astype(datetime)
-
-        def encode_datetime(d):
-            return np.nan if d is None else nc4.date2num(d, units, calendar)
-
-        num = np.vectorize(encode_datetime)(dates)
     return (num, units, calendar)
 
 

--- a/xray/core/dataset.py
+++ b/xray/core/dataset.py
@@ -57,7 +57,8 @@ def open_dataset(filename_or_obj, decode_cf=True, mask_and_scale=True,
         If True, decode the 'coordinates' attribute to identify coordinates in
         the resulting dataset.
     group : str, optional
-        NetCDF4 group in the given file to open (only works for netCDF4).
+        Path to the netCDF4 group in the given file to open (only works for
+        netCDF4).
 
     Returns
     -------
@@ -869,23 +870,78 @@ class Dataset(Mapping, ImplementsDatasetReduce, AttrAccessMixin):
         store.store(variables, attrs)
         store.sync()
 
-    def to_netcdf(self, filepath, **kwdargs):
-        """Dump dataset contents to a location on disk using the netCDF4
-        package.
+    def to_netcdf(self, path=None, mode='w', format=None, group=None):
+        """Write dataset contents to a netCDF file.
+
+        Parameters
+        ----------
+        path : str, optional
+            Path to which to save this dataset. If no path is provided, this
+            function returns the resulting netCDF file as a bytes object (this
+            option only works with the scipy.io.netcdf interface, not with
+            netCDF4-python, so the file cannot be saved with format='NETCDF4').
+        mode : {'w', 'a'}, optional
+            Write ('w') or append ('a') mode. If mode='w', any existing file at
+            this location will be overwritten.
+        format : {'NETCDF4', 'NETCDF4_CLASSIC', 'NETCDF3_64BIT',
+                  'NETCDF3_CLASSIC'}, optional
+            File format for the resulting netCDF file:
+
+            * NETCDF4: Data is stored in an HDF5 file, using netCDF4 API
+              features. This is the default if you are saving a file to disk
+              and have the netCDF4-python library available.
+            * NETCDF4_CLASSIC: Data is stored in an HDF5 file, using only
+              netCDF 3 compatibile API features.
+            * NETCDF3_64BIT: 64-bit offset version of the netCDF 3 file format,
+              which fully supports 2+ GB files, but is only compatible with
+              clients linked against netCDF version 3.6.0 or later. This is the
+              default if you only have scipy available to write netCDF files.
+            * NETCDF3_CLASSIC: The classic netCDF 3 file format. It does not
+              handle 2+ GB files very well.
+
+            All formats are supported by the netCDF4-python library.
+            scipy.io.netcdf only supports the last two formats.
+        group : str, optional
+            Path to the netCDF4 group in the given file to open (only works for
+            format='NETCDF4').
         """
-        with backends.NetCDF4DataStore(filepath, mode='w', **kwdargs) as store:
+        if path is None:
+            fobj = BytesIO()
+            return self._to_scipy_netcdf(fobj, mode, format, group)
+
+        try:
+            self._to_netcdf4(path, mode, format, group)
+        except ImportError:
+            self._to_scipy_netcdf(path, mode, format, group)
+
+    def _to_netcdf4(self, path, mode, format, group):
+        if format is None:
+            format = 'NETCDF4'
+        with backends.NetCDF4DataStore(path, mode=mode, format=format,
+                                       group=group) as store:
             self.dump_to_store(store)
 
-    dump = to_netcdf
+    def _to_scipy_netcdf(self, path, mode, format, group):
+        if group is not None:
+            raise ValueError('cannot save to a group with the '
+                             'scipy.io.netcdf backend')
 
-    def dumps(self, **kwargs):
-        """Serialize dataset contents to a string. The serialization creates an
-        in memory netcdf version 3 string using the scipy.io.netcdf package.
-        """
-        fobj = BytesIO()
-        store = backends.ScipyDataStore(fobj, mode='w', **kwargs)
-        self.dump_to_store(store)
-        return fobj.getvalue()
+        if format is None or format == 'NETCDF3_64BIT':
+            version = 2
+        elif format == 'NETCDF3_CLASSIC':
+            version = 1
+        else:
+            raise ValueError('invalid format for scipy.io.netcdf backend: %r'
+                             % format)
+
+        with backends.ScipyDataStore(path, mode='w', version=version) as store:
+            self.dump_to_store(store)
+
+            if isinstance(path, BytesIO):
+                return path.getvalue()
+
+    dump = utils.function_alias(to_netcdf, 'dumps')
+    dumps = utils.function_alias(to_netcdf, 'dumps')
 
     def __repr__(self):
         return formatting.dataset_repr(self)

--- a/xray/core/dataset.py
+++ b/xray/core/dataset.py
@@ -24,19 +24,22 @@ from .utils import Frozen, SortedKeysDict, ChainMap, maybe_wrap_array
 from .pycompat import iteritems, itervalues, basestring, OrderedDict
 
 
-def open_dataset(filename_or_obj, decode_cf=True, mask_and_scale=True,
-                 decode_times=True, concat_characters=True, decode_coords=True,
-                 group=None):
+def open_dataset(filename_or_obj, group=None, decode_cf=True,
+                 mask_and_scale=True, decode_times=True,
+                 concat_characters=True, decode_coords=True):
     """Load and decode a dataset from a file or file-like object.
 
     Parameters
     ----------
     filename_or_obj : str or file
-        Strings are intrepreted as a path to a netCDF file or an OpenDAP URL
+        Strings are interpreted as a path to a netCDF file or an OpenDAP URL
         and opened with python-netCDF4, unless the filename ends with .gz, in
         which case the file is gunzipped and opened with scipy.io.netcdf (only
         netCDF3 supported). File-like objects are opened with scipy.io.netcdf
         (only netCDF3 supported).
+    group : str, optional
+        Path to the netCDF4 group in the given file to open (only works for
+        netCDF4 files).
     decode_cf : bool, optional
         Whether to decode these variables, assuming they were saved according
         to CF conventions.
@@ -56,9 +59,6 @@ def open_dataset(filename_or_obj, decode_cf=True, mask_and_scale=True,
     decode_coords : bool, optional
         If True, decode the 'coordinates' attribute to identify coordinates in
         the resulting dataset.
-    group : str, optional
-        Path to the netCDF4 group in the given file to open (only works for
-        netCDF4).
 
     Returns
     -------
@@ -81,7 +81,10 @@ def open_dataset(filename_or_obj, decode_cf=True, mask_and_scale=True,
                 else:
                     raise
         else:
-            store = backends.NetCDF4DataStore(filename_or_obj, group=group)
+            try:
+                store = backends.NetCDF4DataStore(filename_or_obj, group=group)
+            except ImportError:
+                store = backends.ScipyDataStore(filename_or_obj)
     else:
         # assume filename_or_obj is a file-like object
         store = backends.ScipyDataStore(filename_or_obj)

--- a/xray/core/dataset.py
+++ b/xray/core/dataset.py
@@ -877,9 +877,9 @@ class Dataset(Mapping, ImplementsDatasetReduce, AttrAccessMixin):
         ----------
         path : str, optional
             Path to which to save this dataset. If no path is provided, this
-            function returns the resulting netCDF file as a bytes object (this
-            option only works with the scipy.io.netcdf interface, not with
-            netCDF4-python, so the file cannot be saved with format='NETCDF4').
+            function returns the resulting netCDF file as a bytes object; in
+            this case, we need to use scipy.io.netcdf, which does not support
+            netCDF version 4 (the default format becomes NETCDF3_64BIT).
         mode : {'w', 'a'}, optional
             Write ('w') or append ('a') mode. If mode='w', any existing file at
             this location will be overwritten.
@@ -888,22 +888,25 @@ class Dataset(Mapping, ImplementsDatasetReduce, AttrAccessMixin):
             File format for the resulting netCDF file:
 
             * NETCDF4: Data is stored in an HDF5 file, using netCDF4 API
-              features. This is the default if you are saving a file to disk
-              and have the netCDF4-python library available.
+              features.
             * NETCDF4_CLASSIC: Data is stored in an HDF5 file, using only
               netCDF 3 compatibile API features.
             * NETCDF3_64BIT: 64-bit offset version of the netCDF 3 file format,
               which fully supports 2+ GB files, but is only compatible with
-              clients linked against netCDF version 3.6.0 or later. This is the
-              default if you only have scipy available to write netCDF files.
+              clients linked against netCDF version 3.6.0 or later.
             * NETCDF3_CLASSIC: The classic netCDF 3 file format. It does not
               handle 2+ GB files very well.
 
             All formats are supported by the netCDF4-python library.
             scipy.io.netcdf only supports the last two formats.
+
+            The default format is NETCDF4 if you are saving a file to disk and
+            have the netCDF4-python library available. Otherwise, xray falls
+            back to using scipy to write netCDF files and defaults to the
+            NETCDF3_64BIT format (scipy does not support netCDF4).
         group : str, optional
             Path to the netCDF4 group in the given file to open (only works for
-            format='NETCDF4').
+            format='NETCDF4'). The group(s) will be created if necessary.
         """
         if path is None:
             fobj = BytesIO()

--- a/xray/test/test_backends.py
+++ b/xray/test/test_backends.py
@@ -603,5 +603,5 @@ class PydapTest(TestCase):
             # don't check attributes since pydap doesn't serialize them correctly
             # also skip the "bears" variable since the test DAP server incorrectly
             # concatenates it.
-            self.assertDatasetEqual(actual.unselect('bears'),
-                                    expected.unselect('bears'))
+            self.assertDatasetEqual(actual.drop_vars('bears'),
+                                    expected.drop_vars('bears'))

--- a/xray/test/test_backends.py
+++ b/xray/test/test_backends.py
@@ -284,7 +284,7 @@ class NetCDF4DataTest(CFEncodedDataTest, TestCase):
     @contextlib.contextmanager
     def roundtrip(self, data, **kwargs):
         with create_tmp_file() as tmp_file:
-            data.dump(tmp_file)
+            data.to_netcdf(tmp_file)
             with open_dataset(tmp_file, **kwargs) as ds:
                 yield ds
 
@@ -356,6 +356,17 @@ class NetCDF4DataTest(CFEncodedDataTest, TestCase):
             for group in 'foo/bar', '/foo/bar', 'foo/bar/', '/foo/bar/':
                 with open_dataset(tmp_file, group=group) as actual:
                     self.assertVariableEqual(actual['x'], expected['x'])
+
+    def test_write_groups(self):
+        data1 = create_test_data()
+        data2 = data1 * 2
+        with create_tmp_file() as tmp_file:
+            data1.to_netcdf(tmp_file, group='data/1')
+            data2.to_netcdf(tmp_file, group='data/2', mode='a')
+            actual1 = open_dataset(tmp_file, group='data/1')
+            actual2 = open_dataset(tmp_file, group='data/2')
+            self.assertDatasetIdentical(data1, actual1)
+            self.assertDatasetIdentical(data2, actual2)
 
     def test_dump_and_open_encodings(self):
         # Create a netCDF file with explicit time units
@@ -504,7 +515,7 @@ class NetCDF4DataTest(CFEncodedDataTest, TestCase):
             xray_dataset = open_dataset(tmp_file)
 
             with create_tmp_file() as tmp_file2:
-                xray_dataset.dump(tmp_file2)
+                xray_dataset.to_netcdf(tmp_file2)
 
                 with nc4.Dataset(tmp_file2, 'r') as ds:
                     self.assertEqual(ds.variables['time'].getncattr('units'), units)
@@ -548,7 +559,7 @@ class ScipyDataTest(CFEncodedDataTest, CastsUnicodeToBytes, TestCase):
 
     @contextlib.contextmanager
     def roundtrip(self, data, **kwargs):
-        serialized = data.dumps()
+        serialized = data.to_netcdf()
         with open_dataset(BytesIO(serialized), **kwargs) as ds:
             yield ds
 
@@ -564,7 +575,7 @@ class NetCDF3ViaNetCDF4DataTest(CFEncodedDataTest, CastsUnicodeToBytes, TestCase
     @contextlib.contextmanager
     def roundtrip(self, data, **kwargs):
         with create_tmp_file() as tmp_file:
-            data.dump(tmp_file, format='NETCDF3_CLASSIC')
+            data.to_netcdf(tmp_file, format='NETCDF3_CLASSIC')
             with open_dataset(tmp_file, **kwargs) as ds:
                 yield ds
 


### PR DESCRIPTION
Fixes #273
and half of #272

To serialize a dataset to a string/bytes, simply use `ds.to_netcdf()`. This behavior copies `DataFrame.to_csv()` from pandas. The legacy `dump` and `dumps` methods are deprecated.

My main concern is that the default "format" option is depends on what dependencies the user has installed or if they are saving a file. That seems non-ideal, but may perhaps be the most pragmatic choice given the limitations of the netCDF4 format.

This change also adds:

- Support for writing datasets to a particular NETCDF4 group
- Support for opening netCDF3 files from disk even without netCDF4-python if scipy is installed.

CC @akleeman 