### PR TITLE
Fix bug associated with reading / writing of mixed endian data.

### DIFF
--- a/xray/backends/netCDF4_.py
+++ b/xray/backends/netCDF4_.py
@@ -89,10 +89,10 @@ def _ensure_fill_value_valid(data, attributes):
 
 def _force_native_endianness(var):
     # possible values for byteorder are:
-    #     ‘=’    native
-    #     ‘<’    little-endian
-    #     ‘>’    big-endian
-    #     ‘|’    not applicable
+    #     =    native
+    #     <    little-endian
+    #     >    big-endian
+    #     |    not applicable
     # Below we check if the data type is not native or NA
     if var.dtype.byteorder not in ['=', '|']:
         # if endianness is specified explicitly, convert to the native type

--- a/xray/backends/netCDF4_.py
+++ b/xray/backends/netCDF4_.py
@@ -173,7 +173,7 @@ class NetCDF4DataStore(AbstractWritableDataStore):
         encoding = variable.encoding
         endian = encoding.get('endian', _endian_lookup[datatype.byteorder])
         data = variable.values
-        if endian is not 'native':
+        if endian == 'big':
             # netCDF4 doesn't seem to support writing of
             # big endian dtypes, so we convert all to little
             # endian.

--- a/xray/test/test_backends.py
+++ b/xray/test/test_backends.py
@@ -439,6 +439,19 @@ class NetCDF4DataTest(CFEncodedDataTest, TestCase):
                 with open_dataset(tmp_file, **kwargs) as actual:
                     self.assertDatasetIdentical(expected, actual)
 
+    def test_roundtrip_endian(self):
+        ds = Dataset({'x': np.arange(3, 10, dtype='>i2'),
+                      'y': np.arange(3, 20, dtype='<i4'),
+                      'z': np.arange(3, 30, dtype='=i8'),
+                      'w': ('x', np.arange(3, 10, dtype=np.float))})
+
+        with self.roundtrip(ds) as actual:
+            # technically these datasets are slightly different,
+            # one hold mixed endian data (ds) the other should be
+            # all big endian (actual).  assertDatasetIdentical
+            # should still pass though.
+            self.assertDatasetIdentical(ds, actual)
+
     def test_roundtrip_character_array(self):
         with create_tmp_file() as tmp_file:
             values = np.array([['a', 'b', 'c'], ['d', 'e', 'f']], dtype='S')


### PR DESCRIPTION
The right solution to this is to figure out how to successfully round trip endian-ness, but that seems to be a deeper issue inside netCDF4 (https://github.com/Unidata/netcdf4-python/issues/346)

Instead we force all data to little endian before netCDF4 write.