### PR TITLE
Add Dataset.drop and DataArray.drop

### DIFF
--- a/doc/data-structures.rst
+++ b/doc/data-structures.rst
@@ -371,7 +371,7 @@ argument ``deep=True``.
 
 You also can select and drop an explicit list of variables by using the
 by indexing with a list of names or using the
-:py:meth:`~xray.Dataset.drop_vars` methods to return a new ``Dataset``. These
+:py:meth:`~xray.Dataset.drop` methods to return a new ``Dataset``. These
 operations keep around coordinates:
 
 .. ipython:: python
@@ -379,12 +379,12 @@ operations keep around coordinates:
     ds[['temperature']]
     ds[['x']]
 
-If a dimension name is given as an argument to `drop_vars`, it also drops all
+If a dimension name is given as an argument to `drop`, it also drops all
 variables that use that dimension:
 
 .. ipython:: python
 
-    ds.drop_vars('time')
+    ds.drop('time')
 
 Another useful option is the ability to rename the variables in a dataset:
 

--- a/doc/indexing.rst
+++ b/doc/indexing.rst
@@ -144,6 +144,18 @@ arrays). However, you can do normal indexing with labeled dimensions:
 Using indexing to *assign* values to a subset of dataset (e.g.,
 ``ds[dict(space=0)] = 1``) is not yet supported.
 
+Dropping labels
+---------------
+
+The :py:meth:`~xray.Dataset.drop` method returns a new object with the listed
+index labels along a dimension dropped:
+
+.. ipython:: python
+
+    ds.drop(['IN', 'IL'], dim='space')
+
+``drop`` is both a ``Dataset`` and ``DataArray`` method.
+
 Indexing details
 ----------------
 

--- a/doc/whats-new.rst
+++ b/doc/whats-new.rst
@@ -76,7 +76,7 @@ Breaking changes
 
   .. ipython:: python
 
-      ds = Dataset({'t': pd.date_range('2000-01-01', periods=12, freq='M')})
+      ds = xray.Dataset({'t': pd.date_range('2000-01-01', periods=12, freq='M')})
       ds['t.season']
 
   Previously, it returned numbered seasons 1 through 4.
@@ -96,6 +96,19 @@ Enhancements
 - `to_netcdf` now supports writing to groups in netCDF4 files (:issue:`333`).
 - `to_netcdf` now works when netcdf4-python is not installed as long as scipy
   is available (:issue:`333`).
+- The new :py:meth:`~xray.Dataset.drop` method makes it easy to drop explicitly
+  listed variables or index labels:
+
+  .. ipython:: python
+
+      # drop variables
+      ds = xray.Dataset({'x': 0, 'y': 1})
+      ds.drop('x')
+
+      # drop index labels
+      arr = xray.DataArray([1, 2, 3], coords=[('x', list('abc'))])
+      arr.drop(['a', 'c'], dim='x')
+
 - TODO: added a documentation example by Joe Hamman.
 
 Bug fixes
@@ -110,6 +123,13 @@ Bug fixes
   multi-dimensional variables (:issue:`315`).
 - Slicing with negative step sizes (:issue:`312`).
 - Invalid conversion of string arrays to numeric dtype (:issue:`305`).
+
+Deprecations
+~~~~~~~~~~~~
+
+- ``dump`` and ``dumps`` have been deprecated in favor of
+  :py:meth:`~xray.Dataset.to_netcdf`.
+- ``drop_vars`` has been deprecated in favor of :py:meth:`~xray.Dataset.drop`.
 
 Future plans
 ~~~~~~~~~~~~

--- a/xray/core/groupby.py
+++ b/xray/core/groupby.py
@@ -183,7 +183,7 @@ class ArrayGroupBy(GroupBy, ImplementsArrayReduce):
         stacked.attrs.update(self.obj.attrs)
 
         name = self.obj.name
-        ds = self.obj._dataset.drop_vars(name)
+        ds = self.obj._dataset.drop(name)
         ds[concat_dim.name] = concat_dim
         # remove extraneous dimensions
         for dim in ds.dims:

--- a/xray/core/utils.py
+++ b/xray/core/utils.py
@@ -192,17 +192,17 @@ def combine_pos_and_kw_args(pos_kwargs, kw_kwargs, func_name):
         return kw_kwargs
 
 
+_SCALAR_TYPES = (datetime.datetime, datetime.date, datetime.timedelta)
+
 def is_scalar(value):
-    """np.isscalar only work on primitive numeric types and (bizarrely)
+    """np.isscalar only works on primitive numeric types and (bizarrely)
     excludes 0-d ndarrays; this version does more comprehensive checks
     """
-    if np.isscalar(value):
-        return True
     if hasattr(value, 'ndim'):
         return value.ndim == 0
-    if isinstance(value, datetime.datetime) or value is None:
-        return True
-    return False
+    return (np.isscalar(value) or
+            isinstance(value, _SCALAR_TYPES) or
+            value is None)
 
 
 def dict_equiv(first, second, compat=equivalent):

--- a/xray/test/test_backends.py
+++ b/xray/test/test_backends.py
@@ -176,7 +176,7 @@ class DatasetIOTestCases(object):
         with self.roundtrip(original) as actual:
             self.assertDatasetIdentical(original, actual)
 
-        expected = original.drop_vars('foo')
+        expected = original.drop('foo')
         with self.roundtrip(expected) as actual:
             self.assertDatasetIdentical(expected, actual)
 
@@ -532,7 +532,7 @@ class NetCDF4DataTest(CFEncodedDataTest, TestCase):
                 self.assertNotIn('coordinates', ds['lat'].attrs)
                 self.assertNotIn('coordinates', ds['lon'].attrs)
 
-        modified = original.drop_vars('temp', 'precip')
+        modified = original.drop(['temp', 'precip'])
         with self.roundtrip(modified) as actual:
             self.assertDatasetIdentical(actual, modified)
         with create_tmp_file() as tmp_file:
@@ -603,5 +603,5 @@ class PydapTest(TestCase):
             # don't check attributes since pydap doesn't serialize them correctly
             # also skip the "bears" variable since the test DAP server incorrectly
             # concatenates it.
-            self.assertDatasetEqual(actual.drop_vars('bears'),
-                                    expected.drop_vars('bears'))
+            self.assertDatasetEqual(actual.drop('bears'),
+                                    expected.drop('bears'))

--- a/xray/test/test_dataarray.py
+++ b/xray/test/test_dataarray.py
@@ -701,6 +701,29 @@ class TestDataArray(TestCase):
     def test_squeeze(self):
         self.assertVariableEqual(self.dv.variable.squeeze(), self.dv.squeeze())
 
+    def test_drop_coordinates(self):
+        expected = DataArray(np.random.randn(2, 3), dims=['x', 'y'])
+        arr = expected.copy()
+        arr.coords['z'] = 2
+        actual = arr.drop('z')
+        self.assertDataArrayIdentical(expected, actual)
+
+        with self.assertRaises(ValueError):
+            arr.drop('not found')
+
+        with self.assertRaisesRegexp(ValueError, 'cannot drop'):
+            arr.drop(None)
+
+        renamed = arr.rename('foo')
+        with self.assertRaisesRegexp(ValueError, 'cannot drop'):
+            renamed.drop('foo')
+
+    def test_drop_index_labels(self):
+        arr = DataArray(np.random.randn(2, 3), dims=['x', 'y'])
+        actual = arr.drop([0, 1], dim='y')
+        expected = arr[:, 2:]
+        self.assertDataArrayIdentical(expected, actual)
+
     def test_dropna(self):
         x = np.random.randn(4, 4)
         x[::2, 0] = np.nan


### PR DESCRIPTION
These are convenient shortcuts for removing variables or index labels from an xray object.