### PR TITLE
Truncate long attributes when printing datasets

### DIFF
--- a/doc/api.rst
+++ b/doc/api.rst
@@ -77,6 +77,7 @@ Comparisons
 
    Dataset.equals
    Dataset.identical
+   Dataset.broadcast_equals
 
 Indexing
 --------
@@ -236,6 +237,7 @@ Comparisons
 
    DataArray.equals
    DataArray.identical
+   DataArray.broadcast_equals
 
 IO / Conversion
 ===============

--- a/doc/examples/monthly-means.rst
+++ b/doc/examples/monthly-means.rst
@@ -1,3 +1,5 @@
+.. _monthly means example:
+
 Calculating Seasonal Averages from Timeseries of Monthly Means
 ==============================================================
 

--- a/doc/whats-new.rst
+++ b/doc/whats-new.rst
@@ -116,12 +116,13 @@ Enhancements
 - Consolidated the functionality of ``dumps`` (writing a dataset to a netCDF3
   bytestring) into :py:meth:`~xray.Dataset.to_netcdf` (:issue:`333`).
 - :py:meth:`~xray.Dataset.to_netcdf` now supports writing to groups in netCDF4
-  files (:issue:`333`). It also now has a full docstring -- you should read it!
+  files (:issue:`333`). It also finally has a full docstring -- you should read
+  it!
 - :py:func:`~xray.open_dataset` and :py:meth:`~xray.Dataset.to_netcdf` now
   work on netCDF4 files when netcdf4-python is not installed as long as scipy
   is available (:issue:`333`).
-- The new :py:meth:`xray.Dataset.drop <Dataset.drop>` and
-  :py:meth:`xray.DataArray.drop <DataArray.drop>` methods makes it easy to drop
+- The new :py:meth:`Dataset.drop <xray.Dataset.drop>` and
+  :py:meth:`DataArray.drop <xray.DataArray.drop>` methods makes it easy to drop
   explicitly listed variables or index labels:
 
   .. ipython:: python
@@ -134,13 +135,13 @@ Enhancements
       arr = xray.DataArray([1, 2, 3], coords=[('x', list('abc'))])
       arr.drop(['a', 'c'], dim='x')
 
-- The :py:meth:`~xray.Dataset.broadcast_equals` has been added to correspond to
+- :py:meth:`~xray.Dataset.broadcast_equals` has been added to correspond to
   the new ``compat`` option.
 - Long attributes are now truncated at 500 characters when printing a dataset
   (:issue:`337`). This should make things more convenient for working with
   datasets interactively.
-- Added a new `documentation example <examples/monthly-means>`_ on calculating
-  properly weighted seasonal means. Thanks Joe Hamman!
+- Added a new documentation example, :ref:`monthly means example`. Thanks Joe
+  Hamman!
 
 Bug fixes
 ~~~~~~~~~

--- a/doc/whats-new.rst
+++ b/doc/whats-new.rst
@@ -136,7 +136,11 @@ Enhancements
 
 - The :py:meth:`~xray.Dataset.broadcast_equals` has been added to correspond to
   the new ``compat`` option.
-- TODO: added a documentation example by Joe Hamman.
+- Long attributes are now truncated at 500 characters when printing a dataset
+  (:issue:`337`). This should make things more convenient for working with
+  datasets interactively.
+- Added a new `documentation example <examples/monthly-means>`_ on calculating
+  properly weighted seasonal means. Thanks Joe Hamman!
 
 Bug fixes
 ~~~~~~~~~

--- a/doc/whats-new.rst
+++ b/doc/whats-new.rst
@@ -138,7 +138,7 @@ Enhancements
 - :py:meth:`~xray.Dataset.broadcast_equals` has been added to correspond to
   the new ``compat`` option.
 - Long attributes are now truncated at 500 characters when printing a dataset
-  (:issue:`337`). This should make things more convenient for working with
+  (:issue:`338`). This should make things more convenient for working with
   datasets interactively.
 - Added a new documentation example, :ref:`monthly means example`. Thanks Joe
   Hamman!

--- a/xray/core/formatting.py
+++ b/xray/core/formatting.py
@@ -143,9 +143,16 @@ def summarize_coord(name, var, col_width):
     return _summarize_var_or_coord(name, var, col_width, show_values, marker)
 
 
+def _maybe_truncate(obj, maxlen=500):
+    s = str(obj)
+    if len(s) > maxlen:
+        s = s[:(maxlen - 3)] + '...'
+    return s
+
+
 def summarize_attr(key, value, col_width=None):
     # ignore col_width for now to more clearly distinguish attributes
-    return '    %s: %s' % (key, value)
+    return '    %s: %s' % (key, _maybe_truncate(value))
 
 
 EMPTY_REPR = '    *empty*'

--- a/xray/test/test_dataset.py
+++ b/xray/test/test_dataset.py
@@ -103,6 +103,10 @@ class TestDataset(TestCase):
         print(actual)
         self.assertEqual(expected, actual)
 
+        # verify long attributes are truncated
+        data = Dataset(attrs={'foo': 'bar' * 1000})
+        self.assertTrue(len(repr(data)) < 1000)
+
     def test_constructor(self):
         x1 = ('x', 2 * np.arange(100))
         x2 = ('x', np.arange(1000))


### PR DESCRIPTION
Only the first 500 characters are now shown, e.g.,

	In [2]: xray.Dataset(attrs={'foo': 'bar' * 1000})
	Out[2]:
	<xray.Dataset>
	Dimensions:  ()
	Coordinates:
	    *empty*
	Data variables:
	    *empty*
	Attributes:
	    foo: barbarbarbarbarbarbarbarbarbarbarbarbarbarbarbarbarbarb
	arbarbarbarbarbarbarbarbarbarbarbarbarbarbarbarbarbarbarbarbarba
	rbarbarbarbarbarbarbarbarbarbarbarbarbarbarbarbarbarbarbarbarbar
	barbarbarbarbarbarbarbarbarbarbarbarbarbarbarbarbarbarbarbarbarb
	arbarbarbarbarbarbarbarbarbarbarbarbarbarbarbarbarbarbarbarbarba
	rbarbarbarbarbarbarbarbarbarbarbarbarbarbarbarbarbarbarbarbarbar
	barbarbarbarbarbarbarbarbarbarbarbarbarbarbarbarbarbarbarbarbarb
	arbarbarbarbarbarbarbarbarbarbarbarbarbarbarbarbarbarbarba...
