### PR TITLE
Fix bug where Coordinates could turn Variable objects in Dataset constructor

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -107,5 +107,5 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 
-xray includes portions of pandas. The license for pandas is included in the
+xray includes portions of pandas and numpy. Their licenses are included in the
 licenses directory.

--- a/licenses/NUMPY_LICENSE
+++ b/licenses/NUMPY_LICENSE
@@ -1,0 +1,30 @@
+Copyright (c) 2005-2011, NumPy Developers.
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are
+met:
+
+    * Redistributions of source code must retain the above copyright
+       notice, this list of conditions and the following disclaimer.
+
+    * Redistributions in binary form must reproduce the above
+       copyright notice, this list of conditions and the following
+       disclaimer in the documentation and/or other materials provided
+       with the distribution.
+
+    * Neither the name of the NumPy Developers nor the names of any
+       contributors may be used to endorse or promote products derived
+       from this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/xray/backends/common.py
+++ b/xray/backends/common.py
@@ -38,11 +38,8 @@ def is_trivial_index(var):
     # if the index is not a 1d integer array
     if var.ndim > 1 or not var.dtype.kind == 'i':
         return False
-    if isinstance(var, Coordinate):
-        arange = np.arange(var.size, dtype=var.dtype)
-        if np.any(var.values != arange):
-            return False
-    return True
+    arange = np.arange(var.size, dtype=var.dtype)
+    return np.all(var.values == arange)
 
 
 class AbstractDataStore(Mapping):

--- a/xray/core/variable.py
+++ b/xray/core/variable.py
@@ -568,7 +568,7 @@ class Variable(common.AbstractArray):
 
         self_dims = set(self.dims)
         exp_dims = tuple(d for d in dims if d not in self_dims) + self.dims
-        exp_data = utils.as_shape(self, [dims[d] for d in exp_dims])
+        exp_data = utils.broadcast_to(self, [dims[d] for d in exp_dims])
         expanded_var = Variable(exp_dims, exp_data, self._attrs,
                                 self._encoding, fastpath=True)
         return expanded_var.transpose(*dims)

--- a/xray/test/test_dataset.py
+++ b/xray/test/test_dataset.py
@@ -155,7 +155,7 @@ class TestDataset(TestCase):
         actual = Dataset({'a': a, 'b': b})
         self.assertDatasetIdentical(expected, actual)
 
-        # regression test for GH???
+        # regression test for GH346
         self.assertIsInstance(actual.variables['x'], Coordinate)
 
         # variable with different dimensions
@@ -195,8 +195,11 @@ class TestDataset(TestCase):
         expected = Dataset({'a': ('x', np.ones(2)),
                             'b': ('y', np.ones(3))},
                            {'c': (('x', 'y'), np.zeros((2, 3)))})
-        actual = Dataset({'a': original['a'][:, 0].drop('y'),
-                          'b': original['a'][0].drop('x')})
+        # use an OrderedDict to ensure test results are reproducible; otherwise
+        # the order of appearance of x and y matters for the order of
+        # dimensions in 'c'
+        actual = Dataset(OrderedDict([('a', original['a'][:, 0].drop('y')),
+                                      ('b', original['a'][0].drop('x'))]))
         self.assertDatasetIdentical(expected, actual)
 
         data = {'x': DataArray(0, coords={'y': 3}), 'y': ('z', [1, 1, 1])}

--- a/xray/test/test_dataset.py
+++ b/xray/test/test_dataset.py
@@ -9,7 +9,7 @@ import numpy as np
 import pandas as pd
 
 from xray import (align, concat, conventions, backends, Dataset, DataArray,
-                  Variable)
+                  Variable, Coordinate)
 from xray.core import indexing, utils
 from xray.core.pycompat import iteritems, OrderedDict
 
@@ -155,13 +155,16 @@ class TestDataset(TestCase):
         actual = Dataset({'a': a, 'b': b})
         self.assertDatasetIdentical(expected, actual)
 
-        # var with different dimensions
+        # regression test for GH???
+        self.assertIsInstance(actual.variables['x'], Coordinate)
+
+        # variable with different dimensions
         c = ('y', [3, 4])
         expected2 = expected.merge({'c': c})
         actual = Dataset({'a': a, 'b': b, 'c': c})
         self.assertDatasetIdentical(expected2, actual)
 
-        # var that is only aligned against the aligned variables
+        # variable that is only aligned against the aligned variables
         d = ('x', [3, 2, 1])
         expected3 = expected.merge({'d': d})
         actual = Dataset({'a': a, 'b': b, 'd': d})
@@ -172,13 +175,28 @@ class TestDataset(TestCase):
             Dataset({'a': a, 'b': b, 'e': e})
 
     def test_constructor_compat(self):
-        data = {'x': DataArray(0, coords={'y': 1}), 'y': ('z', [1, 1, 1])}
+        data = OrderedDict([('x', DataArray(0, coords={'y': 1})),
+                            ('y', ('z', [1, 1, 1]))])
         with self.assertRaisesRegexp(ValueError, 'conflicting value'):
             Dataset(data, compat='equals')
         expected = Dataset({'x': 0}, {'y': ('z', [1, 1, 1])})
         actual = Dataset(data)
         self.assertDatasetIdentical(expected, actual)
         actual = Dataset(data, compat='broadcast_equals')
+        self.assertDatasetIdentical(expected, actual)
+
+        data = OrderedDict([('y', ('z', [1, 1, 1])),
+                            ('x', DataArray(0, coords={'y': 1}))])
+        actual = Dataset(data)
+        self.assertDatasetIdentical(expected, actual)
+
+        original = Dataset({'a': (('x', 'y'), np.ones((2, 3)))},
+                           {'c': (('x', 'y'), np.zeros((2, 3)))})
+        expected = Dataset({'a': ('x', np.ones(2)),
+                            'b': ('y', np.ones(3))},
+                           {'c': (('x', 'y'), np.zeros((2, 3)))})
+        actual = Dataset({'a': original['a'][:, 0].drop('y'),
+                          'b': original['a'][0].drop('x')})
         self.assertDatasetIdentical(expected, actual)
 
         data = {'x': DataArray(0, coords={'y': 3}), 'y': ('z', [1, 1, 1])}

--- a/xray/test/test_utils.py
+++ b/xray/test/test_utils.py
@@ -33,7 +33,7 @@ class TestArrayEquiv(TestCase):
             utils.array_equiv(0, np.array(1, dtype=object)))
 
 
-class TestAsShape(TestCase):
+class TestBroadcastTo(TestCase):
     def test_expand(self):
         for array, shape in [
                 (np.arange(3), (3,)),
@@ -45,14 +45,14 @@ class TestAsShape(TestCase):
                 (np.empty((3, 4), order='F'), (2, 3, 4)),
                 ]:
             _, expected = np.broadcast_arrays(np.empty(shape), array)
-            actual = utils.as_shape(array, shape)
+            actual = utils.broadcast_to(array, shape)
             self.assertArrayEqual(expected, actual)
 
     def test_errors(self):
-        with self.assertRaisesRegexp(ValueError, 'shape must be greater'):
-            utils.as_shape(np.arange(3), ())
-        with self.assertRaisesRegexp(ValueError, 'shape mismatch'):
-            utils.as_shape(np.arange(3), (2,))
+        with self.assertRaises(ValueError):
+            utils.broadcast_to(np.arange(3), ())
+        with self.assertRaises(ValueError):
+            utils.broadcast_to(np.arange(3), (2,))
 
 
 class TestDictionaries(TestCase):


### PR DESCRIPTION
This manifested itself in some variables not being written to netCDF files, because they were determined to be trivial indexes (hence that logic was also updated to be slightly less questionable).