### PR TITLE
Switch the name of datetime components from 'time.month' to 'month'

### DIFF
--- a/doc/data-structures.rst
+++ b/doc/data-structures.rst
@@ -179,6 +179,14 @@ __ http://pandas.pydata.org/pandas-docs/stable/api.html#time-date-components
     foo['time.month']
     foo['time.dayofyear']
 
+xray adds ``'season'`` to the list of datetime components supported by pandas:
+
+.. ipython:: python
+
+    foo['time.season']
+
+The set of valid seasons consists of 'DJF', 'MAM', 'JJA' and 'SON', labeled by
+the first letters of the corresponding months.
 
 Dataset
 -------

--- a/doc/whats-new.rst
+++ b/doc/whats-new.rst
@@ -35,14 +35,14 @@ Breaking changes
       rhs = xray.DataArray([2, 3, 4], [('x', [1, 2, 3])])
       lhs + rhs
 
-  For :ref:`data construction and merging<merge>`, we align based on the
+  :ref:`For dataset construction and merging<merge>`, we align based on the
   **union** of labels:
 
   .. ipython:: python
 
       xray.Dataset({'foo': lhs, 'bar': rhs})
 
-  For :ref:`update and __setitem__<update>`, we align based on the **original**
+  :ref:`For update and __setitem__<update>`, we align based on the **original**
   object:
 
   .. ipython:: python
@@ -76,15 +76,19 @@ Breaking changes
 
   This functionality can be controlled through the ``compat`` option, which
   has also been added to the :py:class:`~xray.Dataset` constructor.
-- We have updated our use of the terms of "coordinates" and "variables". What
-  were known in previous versions of xray as "coordinates" and "variables" are
-  now referred to throughout the documentation as "coordinate variables" and
-  "data variables". This brings xray in closer alignment to `CF Conventions`_.
-  The only visible change besides the documentation is that ``Dataset.vars``
-  has been renamed ``Dataset.data_vars``.
-- You will need to update your code if you have been ignoring deprecation
-  warnings: methods and attributes that were deprecated in xray v0.3 or earlier
-  (e.g., ``dimensions``, ``attributes```) have gone away.
+- Datetime shortcuts such as ``'time.month'`` now return a ``DataArray`` with
+  the name ``'month'``, not ``'time.month'`` (:issue:`345`). This makes it
+  easier to index the resulting arrays when they are used with ``groupby``:
+
+  .. ipython:: python
+
+      time = xray.DataArray(pd.date_range('2000-01-01', periods=365),
+                            dims='time', name='time')
+      counts = time.groupby('time.month').count()
+      counts.sel(month=2)
+
+  Previously, you would need to use something like
+  ``counts.sel(**{'time.month': 2}})``, which is much more awkward.
 - The ``season`` datetime shortcut now returns an array of string labels
   such `'DJF'`:
 
@@ -94,6 +98,15 @@ Breaking changes
       ds['t.season']
 
   Previously, it returned numbered seasons 1 through 4.
+- We have updated our use of the terms of "coordinates" and "variables". What
+  were known in previous versions of xray as "coordinates" and "variables" are
+  now referred to throughout the documentation as "coordinate variables" and
+  "data variables". This brings xray in closer alignment to `CF Conventions`_.
+  The only visible change besides the documentation is that ``Dataset.vars``
+  has been renamed ``Dataset.data_vars``.
+- You will need to update your code if you have been ignoring deprecation
+  warnings: methods and attributes that were deprecated in xray v0.3 or earlier
+  (e.g., ``dimensions``, ``attributes```) have gone away.
 
 .. _bottleneck: https://github.com/kwgoodman/bottleneck
 

--- a/xray/core/dataarray.py
+++ b/xray/core/dataarray.py
@@ -195,6 +195,12 @@ class DataArray(AbstractArray, AttrAccessMixin):
         """
         obj = object.__new__(cls)
         obj._dataset = dataset._copy_listed([name], keep_attrs=False)
+        if name not in obj._dataset:
+            # handle virtual variables
+            try:
+                _, name = name.split('.', 1)
+            except Exception:
+                raise KeyError(name)
         obj._name = name
         if name not in dataset._dims:
             obj._dataset._coord_names.discard(name)

--- a/xray/test/test_dataset.py
+++ b/xray/test/test_dataset.py
@@ -965,8 +965,9 @@ class TestDataset(TestCase):
     def test_virtual_variables(self):
         # access virtual variables
         data = create_test_data()
-        self.assertVariableEqual(data['time.dayofyear'],
-                                 Variable('time', 1 + np.arange(20)))
+        expected = DataArray(1 + np.arange(20), coords=[data['time']],
+                             dims='time', name='dayofyear')
+        self.assertDataArrayIdentical(expected, data['time.dayofyear'])
         self.assertArrayEqual(data['time.month'].values,
                               data.variables['time'].to_index().month)
         self.assertArrayEqual(data['time.season'].values, 'DJF')
@@ -975,7 +976,7 @@ class TestDataset(TestCase):
         self.assertArrayEqual(np.sin(data['time.dayofyear']),
                               np.sin(1 + np.arange(20)))
         # ensure they become coordinates
-        expected = Dataset({}, {'time.dayofyear': data['time.dayofyear']})
+        expected = Dataset({}, {'dayofyear': data['time.dayofyear']})
         actual = data[['time.dayofyear']]
         self.assertDatasetEqual(expected, actual)
         # non-coordinate variables
@@ -1190,7 +1191,7 @@ class TestDataset(TestCase):
         grouped = ds.groupby('t.day')
         actual = grouped - grouped.mean()
         expected = Dataset({'x': ('t', [0, 0, 0])},
-                           {'t': ds['t'], 't.day': ds['t.day']})
+                           ds[['t', 't.day']])
         self.assertDatasetIdentical(actual, expected)
 
     def test_groupby_nan(self):


### PR DESCRIPTION
Fixes #345

This lets you write things like:

    counts = time.groupby('time.month').count()
    counts.sel(month=2)

instead of the previously valid

    counts.sel(**{'time.month': 2})

which is much more awkward. Note that this breaks existing code which relied on the old usage.

CC @jhamman 