### PR TITLE
Raise informative exception when _FillValue and missing_value disagree

### DIFF
--- a/xray/conventions.py
+++ b/xray/conventions.py
@@ -674,9 +674,15 @@ def decode_cf_variable(var, concat_characters=True, mask_and_scale=True,
         if 'missing_value' in attributes:
             # missing_value is deprecated, but we still want to support it as
             # an alias for _FillValue.
-            assert ('_FillValue' not in attributes
+            if not ('_FillValue' not in attributes
                     or utils.equivalent(attributes['_FillValue'],
-                                        attributes['missing_value']))
+                                        attributes['missing_value'])):
+                raise ValueError("Discovered conflicting _FillValue "
+                                 "and missing_value.  Considering "
+                                 "opening the offending dataset using "
+                                 "decode_cf=False, corrected the attributes",
+                                 "and decoding explicitly using "
+                                 "xray.conventions.decode_cf(ds)")
             attributes['_FillValue'] = attributes.pop('missing_value')
 
         fill_value = pop_to(attributes, encoding, '_FillValue')

--- a/xray/conventions.py
+++ b/xray/conventions.py
@@ -674,9 +674,9 @@ def decode_cf_variable(var, concat_characters=True, mask_and_scale=True,
         if 'missing_value' in attributes:
             # missing_value is deprecated, but we still want to support it as
             # an alias for _FillValue.
-            if not ('_FillValue' not in attributes
-                    or utils.equivalent(attributes['_FillValue'],
-                                        attributes['missing_value'])):
+            if ('_FillValue' in attributes
+                and not utils.equivalent(attributes['_FillValue'],
+                                         attributes['missing_value'])):
                 raise ValueError("Discovered conflicting _FillValue "
                                  "and missing_value.  Considering "
                                  "opening the offending dataset using "

--- a/xray/test/test_conventions.py
+++ b/xray/test/test_conventions.py
@@ -196,6 +196,14 @@ class TestDatetime(TestCase):
         actual = conventions.decode_cf_datetime(np.arange(100), units)
         self.assertArrayEqual(actual, expected)
 
+    def test_decode_cf_with_conflicting_fill_missing_value(self):
+        var = Variable(['t'], np.arange(10),
+                       {'units': 'foobar',
+                        'missing_value': 0,
+                        '_FillValue': 1})
+        self.assertRaisesRegexp(ValueError, "_FillValue and missing_value",
+                                lambda: conventions.decode_cf_variable(var))
+
     @requires_netCDF4
     def test_decode_cf_datetime_non_iso_strings(self):
         # datetime strings that are _almost_ ISO compliant but not quite,


### PR DESCRIPTION
Previously conflicting _FillValue and missing_value only raised an AssertionError, now it's more informative.