### PR TITLE
Add resample, first and last

### DIFF
--- a/doc/api.rst
+++ b/doc/api.rst
@@ -101,6 +101,7 @@ Computation
    Dataset.apply
    Dataset.reduce
    Dataset.groupby
+   Dataset.resample
    Dataset.transpose
 
 **Aggregation**:
@@ -197,6 +198,7 @@ Computation
 
    DataArray.reduce
    DataArray.groupby
+   DataArray.resample
    DataArray.transpose
    DataArray.get_axis_num
 

--- a/doc/examples/_code/monthly_averaging.py
+++ b/doc/examples/_code/monthly_averaging.py
@@ -1,8 +1,0 @@
-def year_month(xray_obj):
-    """Given an xray object with a 'time' coordinate, return an DataArray
-    with values given by the first date of the month in which each time
-    falls.
-    """
-    time = xray_obj.coords['time']
-    values = time.to_index().to_period('M').to_timestamp()
-    return xray.DataArray(values, [time], name='year_month')

--- a/doc/examples/weather-data.rst
+++ b/doc/examples/weather-data.rst
@@ -48,28 +48,24 @@ Probability of freeze by calendar month
     freeze
 
     @savefig examples_freeze_prob.png
-    freeze.to_series().unstack('location').plot()
-
+    freeze.to_pandas().T.plot()
 
 Monthly averaging
 -----------------
 
-.. literalinclude:: _code/monthly_averaging.py
-
-.. ipython:: python
-   :suppress:
-
-   execfile("examples/_code/monthly_averaging.py")
-
 .. ipython:: python
 
-    monthly_avg = ds.groupby(year_month(ds)).mean()
+    monthly_avg = ds.resample('1MS', dim='time', how='mean')
 
     @savefig examples_tmin_tmax_plot_mean.png
-    monthly_avg.to_dataframe().plot(style='s-')
+    monthly_avg.sel(location='IA').to_dataframe().plot(style='s-')
 
-We do plan to eventually add a ``resample`` method like pandas to make this
-more convenient (:issue:`354`).
+Resample uses the `same api`_ as ``resample`` in pandas. Note that ``MS`` here
+refers to Month-Start; ``M`` labels Month-End (the last day of the month). The
+full of these offset aliases is `documented in pandas`_.
+
+.. _same api: http://pandas.pydata.org/pandas-docs/stable/timeseries.html#up-and-downsampling
+.. _documented in pandas: http://pandas.pydata.org/pandas-docs/stable/timeseries.html#offset-aliases
 
 Calculate monthly anomalies
 ---------------------------

--- a/doc/groupby.rst
+++ b/doc/groupby.rst
@@ -90,6 +90,16 @@ dimensions *other than* the provided one:
 
     ds.groupby('x').reduce(np.nanmean)
 
+First and last
+~~~~~~~~~~~~~~
+
+TODO
+
+Resampling
+~~~~~~~~~~
+
+TODO
+
 Grouped arithmetic
 ~~~~~~~~~~~~~~~~~~
 

--- a/doc/whats-new.rst
+++ b/doc/whats-new.rst
@@ -17,29 +17,41 @@ The release contains bug fixes and backwards compatible changes.
 New features
 ~~~~~~~~~~~~
 
-- ``resample`` lets you resample a dataset or array along a time axis to a
-  coarser resolution. The syntax is the `same as pandas`_, except you need to
-  supply the time dimension explicitly:
+- ``resample`` lets you resample a new temporal resolution. The syntax is the
+  `same as pandas`_, except you need to supply the time dimension explicitly:
 
   .. ipython:: python
 
-    time = pd.date_range('2000-01-01', freq='6H', periods=10)
-    array = xray.DataArray(np.arange(10), [('time', time)])
-    array.resample('1D', dim='time')
+      time = pd.date_range('2000-01-01', freq='6H', periods=10)
+      array = xray.DataArray(np.arange(10), [('time', time)])
+      array.resample('1D', dim='time')
 
   You can specify how to do the resampling with the ``how`` argument and other
   options such as ``closed`` and ``label`` let you control labeling:
 
   .. ipython:: python
 
-    array.resample('1D', dim='time', how='sum', label='right')
+      array.resample('1D', dim='time', how='sum', label='right')
+
+  If the desired temporal resolution is higher than the original data
+  (upsampling), xray will insert missing values:
+
+  .. ipython:: python
+
+      array.resample('3H', 'time')
 
 - ``first`` and ``last`` methods on groupby objects let you take the first or
   last examples from each group along the grouped axis:
 
   .. ipython:: python
 
-    array.groupby('time.day').first()
+      array.groupby('time.day').first()
+
+  These methods combine well with ``resample``:
+
+  .. ipython:: python
+
+      array.resample('1D', dim='time', how='first')
 
 .. _same as pandas: http://pandas.pydata.org/pandas-docs/stable/timeseries.html#up-and-downsampling
 

--- a/doc/whats-new.rst
+++ b/doc/whats-new.rst
@@ -58,6 +58,12 @@ New features
 
 TODO: write full docs on time-series!
 
+Bug fixes
+~~~~~~~~~
+
+- Dataset aggregations with ``keep_attrs=True`` now preserve attributes on
+  data variables, not just the dataset itself.
+
 v0.4 (2 March, 2015)
 --------------------
 

--- a/doc/whats-new.rst
+++ b/doc/whats-new.rst
@@ -9,6 +9,42 @@ What's New
     import xray
     np.random.seed(123456)
 
+v0.4.1 (unreleased)
+-------------------
+
+The release contains bug fixes and backwards compatible changes.
+
+New features
+~~~~~~~~~~~~
+
+- ``resample`` lets you resample a dataset or array along a time axis to a
+  coarser resolution. The syntax is the `same as pandas`_, except you need to
+  supply the time dimension explicitly:
+
+  .. ipython:: python
+
+    time = pd.date_range('2000-01-01', freq='6H', periods=10)
+    array = xray.DataArray(np.arange(10), [('time', time)])
+    array.resample('1D', dim='time')
+
+  You can specify how to do the resampling with the ``how`` argument and other
+  options such as ``closed`` and ``label`` let you control labeling:
+
+  .. ipython:: python
+
+    array.resample('1D', dim='time', how='sum', label='right')
+
+- ``first`` and ``last`` methods on groupby objects let you take the first or
+  last examples from each group along the grouped axis:
+
+  .. ipython:: python
+
+    array.groupby('time.day').first()
+
+.. _same as pandas: http://pandas.pydata.org/pandas-docs/stable/timeseries.html#up-and-downsampling
+
+TODO: write full docs on time-series!
+
 v0.4 (2 March, 2015)
 --------------------
 
@@ -330,8 +366,8 @@ Bug fixes
   (:issue:`254`).
 - Order of dimensions preserved with ``DataArray.to_dataframe`` (:issue:`260`).
 
-v0.3.0 (21 September 2014)
---------------------------
+v0.3 (21 September 2014)
+------------------------
 
 New features
 ~~~~~~~~~~~~
@@ -368,8 +404,8 @@ Deprecations
 - ``DataArray.select_vars`` and ``DataArray.drop_vars`` deprecated: use
   :py:meth:`~xray.DataArray.reset_coords` instead.
 
-v0.2.0 (14 August 2014)
------------------------
+v0.2 (14 August 2014)
+---------------------
 
 This is major release that includes some new features and quite a few bug
 fixes. Here are the highlights:

--- a/doc/whats-new.rst
+++ b/doc/whats-new.rst
@@ -17,8 +17,9 @@ The release contains bug fixes and backwards compatible changes.
 New features
 ~~~~~~~~~~~~
 
-- ``resample`` lets you resample a new temporal resolution. The syntax is the
-  `same as pandas`_, except you need to supply the time dimension explicitly:
+- :py:meth`~xray.Dataset.resample` lets you resample a dataset or data array to
+  a new temporal resolution. The syntax is the `same as pandas`_, except you
+  need to supply the time dimension explicitly:
 
   .. ipython:: python
 

--- a/xray/core/common.py
+++ b/xray/core/common.py
@@ -190,7 +190,7 @@ class BaseDataObject(AttrAccessMixin):
         if isinstance(how, basestring):
             f = getattr(gb, how)
             if how in ['first', 'last']:
-                result = f()
+                result = f(skipna=skipna)
             else:
                 result = f(dim=dim.name, skipna=skipna)
         else:

--- a/xray/core/common.py
+++ b/xray/core/common.py
@@ -140,6 +140,55 @@ class AttrAccessMixin(object):
         return sorted(set(dir(type(self)) + extra_attrs))
 
 
+class BaseDataObject(AttrAccessMixin):
+    def groupby(self, group, squeeze=True):
+        """Returns a GroupBy object for performing grouped operations.
+
+        Parameters
+        ----------
+        group : str, DataArray or Coordinate
+            Array whose unique values should be used to group this array. If a
+            string, must be the name of a variable contained in this dataset.
+        squeeze : boolean, optional
+            If "group" is a dimension of any arrays in this dataset, `squeeze`
+            controls whether the subarrays have a dimension of length 1 along
+            that dimension or if the dimension is squeezed out.
+
+        Returns
+        -------
+        grouped : GroupBy
+            A `GroupBy` object patterned after `pandas.GroupBy` that can be
+            iterated over in the form of `(unique_value, grouped_array)` pairs.
+        """
+        if isinstance(group, basestring):
+            group = self[group]
+        return self.groupby_cls(self, group, squeeze=squeeze)
+
+    def resample(self, freq, dim, how='mean', skipna=None, closed=None,
+                 label=None, base=0):
+        """
+        freq : pandas date offset or offset alias for identifying bin edges
+        closed : closed end of interval; left or right
+        label : interval boundary to use for labeling; left or right
+        """
+        from .dataarray import DataArray
+
+        RESAMPLE_DIM = '__resample_dim__'
+        if isinstance(dim, basestring):
+            dim = self[dim]
+        group = DataArray(dim, name=RESAMPLE_DIM)
+        time_grouper = pd.TimeGrouper(freq=freq, how=how, closed=closed,
+                                      label=label, base=base)
+        gb = self.groupby_cls(self, group, time_grouper=time_grouper)
+        f = getattr(gb, how)
+        if how in ['first', 'last']:
+            result = f()
+        else:
+            result = f(dim=dim.name, skipna=None)
+        result = result.rename({RESAMPLE_DIM: dim.name})
+        return result
+
+
 def squeeze(xray_obj, dims, dim=None):
     """Squeeze the dims of an xray object."""
     if dim is None:

--- a/xray/core/dataarray.py
+++ b/xray/core/dataarray.py
@@ -570,32 +570,6 @@ class DataArray(AbstractArray, BaseDataObject):
         renamed_dataset = self._dataset.rename(name_dict)
         return renamed_dataset[new_name]
 
-    # def groupby(self, group, squeeze=True):
-    #     """Returns a GroupBy object for performing grouped operations.
-
-    #     Parameters
-    #     ----------
-    #     group : str, DataArray or Coordinate
-    #         Array whose unique values should be used to group this array. If a
-    #         string, must be the name of a variable contained in this dataset.
-    #     squeeze : boolean, optional
-    #         If "group" is a diension of this array, `squeeze` controls
-    #         whether the subarrays have a dimension of length 1 along that
-    #         dimension or if the dimension is squeezed out.
-
-    #     Returns
-    #     -------
-    #     grouped : GroupBy
-    #         A `GroupBy` object patterned after `pandas.GroupBy` that can be
-    #         iterated over in the form of `(unique_value, grouped_array)` pairs
-    #         or over which grouped operations can be applied with the `apply`
-    #         and `reduce` methods (and the associated aliases `mean`, `sum`,
-    #         `std`, etc.).
-    #     """
-    #     if isinstance(group, basestring):
-    #         group = self.coords[group]
-    #     return groupby.ArrayGroupBy(self, group, squeeze=squeeze)
-
     def transpose(self, *dims):
         """Return a new DataArray object with transposed dimensions.
 

--- a/xray/core/dataarray.py
+++ b/xray/core/dataarray.py
@@ -9,7 +9,7 @@ from . import ops
 from . import utils
 from . import variable
 from .alignment import align
-from .common import AbstractArray, AttrAccessMixin
+from .common import AbstractArray, BaseDataObject
 from .coordinates import DataArrayCoordinates, Indexes
 from .dataset import Dataset
 from .pycompat import iteritems, basestring, OrderedDict, zip
@@ -82,7 +82,7 @@ class _LocIndexer(object):
         self.data_array[self._remap_key(key)] = value
 
 
-class DataArray(AbstractArray, AttrAccessMixin):
+class DataArray(AbstractArray, BaseDataObject):
     """N-dimensional array with labeled coordinates and dimensions.
 
     DataArray provides a wrapper around numpy ndarrays that uses labeled
@@ -120,6 +120,8 @@ class DataArray(AbstractArray, AttrAccessMixin):
     attrs : OrderedDict
         Dictionary for holding arbitrary metadata.
     """
+    groupby_cls = groupby.ArrayGroupBy
+
     def __init__(self, data, coords=None, dims=None, name=None,
                  attrs=None, encoding=None):
         """
@@ -568,31 +570,31 @@ class DataArray(AbstractArray, AttrAccessMixin):
         renamed_dataset = self._dataset.rename(name_dict)
         return renamed_dataset[new_name]
 
-    def groupby(self, group, squeeze=True):
-        """Returns a GroupBy object for performing grouped operations.
+    # def groupby(self, group, squeeze=True):
+    #     """Returns a GroupBy object for performing grouped operations.
 
-        Parameters
-        ----------
-        group : str, DataArray or Coordinate
-            Array whose unique values should be used to group this array. If a
-            string, must be the name of a variable contained in this dataset.
-        squeeze : boolean, optional
-            If "group" is a diension of this array, `squeeze` controls
-            whether the subarrays have a dimension of length 1 along that
-            dimension or if the dimension is squeezed out.
+    #     Parameters
+    #     ----------
+    #     group : str, DataArray or Coordinate
+    #         Array whose unique values should be used to group this array. If a
+    #         string, must be the name of a variable contained in this dataset.
+    #     squeeze : boolean, optional
+    #         If "group" is a diension of this array, `squeeze` controls
+    #         whether the subarrays have a dimension of length 1 along that
+    #         dimension or if the dimension is squeezed out.
 
-        Returns
-        -------
-        grouped : GroupBy
-            A `GroupBy` object patterned after `pandas.GroupBy` that can be
-            iterated over in the form of `(unique_value, grouped_array)` pairs
-            or over which grouped operations can be applied with the `apply`
-            and `reduce` methods (and the associated aliases `mean`, `sum`,
-            `std`, etc.).
-        """
-        if isinstance(group, basestring):
-            group = self.coords[group]
-        return groupby.ArrayGroupBy(self, group, squeeze=squeeze)
+    #     Returns
+    #     -------
+    #     grouped : GroupBy
+    #         A `GroupBy` object patterned after `pandas.GroupBy` that can be
+    #         iterated over in the form of `(unique_value, grouped_array)` pairs
+    #         or over which grouped operations can be applied with the `apply`
+    #         and `reduce` methods (and the associated aliases `mean`, `sum`,
+    #         `std`, etc.).
+    #     """
+    #     if isinstance(group, basestring):
+    #         group = self.coords[group]
+    #     return groupby.ArrayGroupBy(self, group, squeeze=squeeze)
 
     def transpose(self, *dims):
         """Return a new DataArray object with transposed dimensions.

--- a/xray/core/dataset.py
+++ b/xray/core/dataset.py
@@ -1510,16 +1510,17 @@ class Dataset(Mapping, ImplementsDatasetReduce, BaseDataObject):
             if reduce_dims or not var.dims:
                 if name not in self.coords:
                     if not numeric_only or var.dtype.kind in 'ifcb':
-                        if len(reduce_dims) == var.ndim:
+                        if len(reduce_dims) == 1:
+                            # unpack dimensions for the benefit of functions
+                            # like np.argmin which can't handle tuple arguments
+                            reduce_dims, = reduce_dims
+                        elif len(reduce_dims) == var.ndim:
                             # prefer to aggregate over axis=None rather than
                             # axis=(0, 1) if they will be equivalent, because
                             # the former is often more efficient
                             reduce_dims = None
-                        elif len(reduce_dims) == 1:
-                            # unpack dimensions for the benefit of functions
-                            # like np.argmin which can't handle tuple arguments
-                            reduce_dims, = reduce_dims
                         variables[name] = var.reduce(func, dim=reduce_dims,
+                                                     keep_attrs=keep_attrs,
                                                      **kwargs)
             else:
                 variables[name] = var

--- a/xray/core/groupby.py
+++ b/xray/core/groupby.py
@@ -181,28 +181,17 @@ class GroupBy(object):
             combined = combined.reindex(**indexers)
         return combined
 
-    def _get_element(self, n):
-        sl = {self.group_dim: n}
-
-        def f(x):
-            res = x.isel(**sl)
-            if not isinstance(res, Variable):
-                # drop group_dim to ensure those labels don't get used
-                # (they get inserted again later)
-                res = res.drop(self.group_dim)
-            return res
-
-        return self.apply(f, shortcut=True)
-
-    def first(self):
+    def first(self, skipna=None, keep_attrs=True):
         """Return the first element of each group along the group dimension
         """
-        return self._get_element(0)
+        return self.reduce(ops.first, self.group_dim, skipna=skipna,
+                           keep_attrs=keep_attrs)
 
-    def last(self):
+    def last(self, skipna=None, keep_attrs=True):
         """Return the last element of each group along the group dimension
         """
-        return self._get_element(-1)
+        return self.reduce(ops.last, self.group_dim, skipna=skipna,
+                           keep_attrs=keep_attrs)
 
 
 class ArrayGroupBy(GroupBy, ImplementsArrayReduce):

--- a/xray/core/groupby.py
+++ b/xray/core/groupby.py
@@ -65,6 +65,8 @@ class GroupBy(object):
             If "group" is a coordinate of object, `squeeze` controls whether
             the subarrays have a dimension of length 1 along that coordinate or
             if the dimension is squeezed out.
+        grouper : pd.Grouper, optional
+            Used for grouping values along the `group` array.
         """
         from .dataset import as_dataset
 

--- a/xray/test/test_dataarray.py
+++ b/xray/test/test_dataarray.py
@@ -994,6 +994,17 @@ class TestDataArray(TestCase):
         expected = DataArray(array.to_series().resample('24H', how='first'))
         self.assertDataArrayIdentical(expected, actual)
 
+        # missing values
+        array = array.astype(float)
+        array[:2] = np.nan
+        actual = array.resample('1D', dim='time', how='first')
+        expected = DataArray([2, 4, 8], [('time', times[::4])])
+        self.assertDataArrayIdentical(expected, actual)
+
+        actual = array.resample('1D', dim='time', how='first', skipna=False)
+        expected = DataArray([np.nan, 4, 8], [('time', times[::4])])
+        self.assertDataArrayIdentical(expected, actual)
+
     def test_resample_skipna(self):
         times = pd.date_range('2000-01-01', freq='6H', periods=10)
         array = DataArray(np.ones(10), [('time', times)])

--- a/xray/test/test_dataarray.py
+++ b/xray/test/test_dataarray.py
@@ -978,6 +978,9 @@ class TestDataArray(TestCase):
         actual = array.resample('24H', dim='time', how=np.mean)
         self.assertDataArrayIdentical(expected, actual)
 
+        with self.assertRaisesRegexp(ValueError, 'index must be monotonic'):
+            array[[2, 0, 1]].resample('1D', dim='time')
+
     def test_resample_first(self):
         times = pd.date_range('2000-01-01', freq='6H', periods=10)
         array = DataArray(np.arange(10), [('time', times)])
@@ -993,11 +996,11 @@ class TestDataArray(TestCase):
 
     def test_resample_skipna(self):
         times = pd.date_range('2000-01-01', freq='6H', periods=10)
-        array = DataArray(np.arange(10.0), [('time', times)])
-        array[0] = np.nan
+        array = DataArray(np.ones(10), [('time', times)])
+        array[1] = np.nan
 
-        actual = array.resample('1D', dim='time', how='first', skipna=False)
-        expected = DataArray([np.nan, 4, 8], [('time', times[::4])])
+        actual = array.resample('1D', dim='time', skipna=False)
+        expected = DataArray([np.nan, 1, 1], [('time', times[::4])])
         self.assertDataArrayIdentical(expected, actual)
 
     def test_resample_upsampling(self):

--- a/xray/test/test_dataarray.py
+++ b/xray/test/test_dataarray.py
@@ -948,6 +948,39 @@ class TestDataArray(TestCase):
         with self.assertRaisesRegexp(TypeError, 'only support arithmetic'):
             grouped + grouped
 
+    def test_groupby_first_and_last(self):
+        array = DataArray([1, 2, 3, 4, 5], dims='x')
+        by = DataArray(['a'] * 2 + ['b'] * 3, dims='x', name='ab')
+
+        expected = DataArray([1, 3], [('ab', ['a', 'b'])])
+        actual = array.groupby(by).first()
+        self.assertDataArrayIdentical(expected, actual)
+
+        expected = DataArray([2, 5], [('ab', ['a', 'b'])])
+        actual = array.groupby(by).last()
+        self.assertDataArrayIdentical(expected, actual)
+
+        array = DataArray(np.random.randn(5, 3), dims=['x', 'y'])
+        expected = DataArray(array[[0, 2]], {'ab': ['a', 'b']}, ['ab', 'y'])
+        actual = array.groupby(by).first()
+
+    def test_resample(self):
+        times = pd.date_range('2000-01-01', freq='6H', periods=10)
+        array = DataArray(np.arange(10), [('time', times)])
+
+        actual = array.resample('24H', dim='time')
+        expected = DataArray(array.to_series().resample('24H'))
+        self.assertDataArrayIdentical(expected, actual)
+
+        actual = array.resample('1D', dim='time', how='first')
+        expected = DataArray([0, 4, 8], [('time', times[::4])])
+        self.assertDataArrayIdentical(expected, actual)
+
+        # verify that labels don't use the first value
+        actual = array.resample('24H', dim='time', how='first')
+        expected = DataArray(array.to_series().resample('24H', how='first'))
+        self.assertDataArrayIdentical(expected, actual)
+
     def test_concat(self):
         self.ds['bar'] = Variable(['x', 'y'], np.random.randn(10, 20))
         foo = self.ds['foo']

--- a/xray/test/test_dataset.py
+++ b/xray/test/test_dataset.py
@@ -1531,13 +1531,15 @@ class TestDataset(TestCase):
 
         # Test dropped attrs
         ds = data.mean()
-        self.assertEqual(len(ds.attrs), 0)
-        self.assertEqual(ds.attrs, OrderedDict())
+        self.assertEqual(ds.attrs, {})
+        for v in ds.data_vars.values():
+            self.assertEqual(v.attrs, {})
 
         # Test kept attrs
         ds = data.mean(keep_attrs=True)
-        self.assertEqual(len(ds.attrs), len(_attrs))
-        self.assertTrue(ds.attrs, attrs)
+        self.assertEqual(ds.attrs, attrs)
+        for k, v in ds.data_vars.items():
+            self.assertEqual(v.attrs, data[k].attrs)
 
     def test_reduce_argmin(self):
         # regression test for #205
@@ -1585,8 +1587,10 @@ class TestDataset(TestCase):
         data.attrs['foo'] = 'bar'
 
         self.assertDatasetIdentical(data.apply(np.mean), data.mean())
-        self.assertDatasetIdentical(data.apply(np.mean, keep_attrs=True),
-                                    data.mean(keep_attrs=True))
+
+        expected = data.mean(keep_attrs=True)
+        actual = data.apply(lambda x: x.mean(keep_attrs=True), keep_attrs=True)
+        self.assertDatasetIdentical(expected, actual)
 
         self.assertDatasetIdentical(data.apply(lambda x: x, keep_attrs=True),
                                     data.drop('time'))

--- a/xray/test/test_dataset.py
+++ b/xray/test/test_dataset.py
@@ -1213,6 +1213,13 @@ class TestDataset(TestCase):
         expected = ds.isel(time=[0, 4, 8])
         self.assertDatasetIdentical(expected, actual)
 
+        # upsampling
+        expected_time = pd.date_range('2000-01-01', freq='3H', periods=19)
+        expected = ds.reindex(time=expected_time)
+        for how in ['mean', 'sum', 'first', 'last', np.mean]:
+            actual = ds.resample('3H', 'time', how=how)
+            self.assertDatasetEqual(expected, actual)
+
     def test_concat(self):
         data = create_test_data()
 

--- a/xray/test/test_dataset.py
+++ b/xray/test/test_dataset.py
@@ -1202,6 +1202,17 @@ class TestDataset(TestCase):
         expected = Dataset({'foo': ('bar', [1.5, 3]), 'bar': [1, 2]})
         self.assertDatasetIdentical(actual, expected)
 
+    def test_resample_and_first(self):
+        times = pd.date_range('2000-01-01', freq='6H', periods=10)
+        ds = Dataset({'foo': (['time', 'x', 'y'], np.random.randn(10, 5, 3)),
+                      'bar': ('time', np.random.randn(10), {'meta': 'data'}),
+                      'baz': ('x', np.random.randn(5)),
+                      'time': times})
+
+        actual = ds.resample('1D', dim='time', how='first')
+        expected = ds.isel(time=[0, 4, 8])
+        self.assertDatasetIdentical(expected, actual)
+
     def test_concat(self):
         data = create_test_data()
 

--- a/xray/test/test_ops.py
+++ b/xray/test/test_ops.py
@@ -1,0 +1,69 @@
+from numpy import array, nan
+from xray.core.ops import first, last, count
+
+from . import TestCase
+
+
+class TestOps(TestCase):
+    def setUp(self):
+        self.x = array([[[ nan,  nan,   2.,  nan],
+                         [ nan,   5.,   6.,  nan],
+                         [  8.,   9.,  10.,  nan]],
+
+                        [[ nan,  13.,  14.,  15.],
+                         [ nan,  17.,  18.,  nan],
+                         [ nan,  21.,  nan,  nan]]])
+
+    def test_first(self):
+        expected_results = [array([[nan, 13, 2, 15],
+                                   [nan, 5, 6, nan],
+                                   [8, 9, 10, nan]]),
+                            array([[8, 5, 2, nan],
+                                   [nan, 13, 14, 15]]),
+                            array([[2, 5, 8],
+                                   [13, 17, 21]])]
+        for axis, expected in zip([0, 1, 2, -3, -2, -1],
+                                  2 * expected_results):
+            actual = first(self.x, axis)
+            self.assertArrayEqual(expected, actual)
+
+        expected = self.x[0]
+        actual = first(self.x, axis=0, skipna=False)
+        self.assertArrayEqual(expected, actual)
+
+        expected = self.x[..., 0]
+        actual = first(self.x, axis=-1, skipna=False)
+        self.assertArrayEqual(expected, actual)
+
+        with self.assertRaisesRegexp(ValueError, 'invalid axis'):
+            first(self.x, 3)
+
+    def test_last(self):
+        expected_results = [array([[nan, 13, 14, 15],
+                                   [nan, 17, 18, nan],
+                                   [8, 21, 10, nan]]),
+                            array([[8, 9, 10, nan],
+                                   [nan, 21, 18, 15]]),
+                            array([[2, 6, 10],
+                                   [15, 18, 21]])]
+        for axis, expected in zip([0, 1, 2, -3, -2, -1],
+                                  2 * expected_results):
+            actual = last(self.x, axis)
+            self.assertArrayEqual(expected, actual)
+
+        expected = self.x[-1]
+        actual = last(self.x, axis=0, skipna=False)
+        self.assertArrayEqual(expected, actual)
+
+        expected = self.x[..., -1]
+        actual = last(self.x, axis=-1, skipna=False)
+        self.assertArrayEqual(expected, actual)
+
+        with self.assertRaisesRegexp(ValueError, 'invalid axis'):
+            last(self.x, 3)
+
+    def test_count(self):
+        self.assertEqual(12, count(self.x))
+
+        expected = array([[1, 2, 3], [3, 2, 1]])
+        self.assertArrayEqual(expected, count(self.x, axis=-1))


### PR DESCRIPTION
Fixes #354

`resample` lets you resample a dataset or array along a time axis to a coarser
resolution. The syntax is the same as pandas, except you need to supply the
time dimension explicitly:

    In [1]: time = pd.date_range('2000-01-01', freq='6H', periods=10)

    In [2]: array = xray.DataArray(np.arange(10), [('time', time)])

    In [3]: array.resample('1D', dim='time')
    Out[3]:
    <xray.DataArray (time: 3)>
    array([ 1.5,  5.5,  8.5])
    Coordinates:
      * time     (time) datetime64[ns] 2000-01-01 2000-01-02 2000-01-03

You can specify how to do the resampling with the how argument and other
options such as closed and label let you control labeling:

    In [4]: array.resample('1D', dim='time', how='sum', label='right')
    Out[4]:
    <xray.DataArray (time: 3)>
    array([ 6, 22, 17])
    Coordinates:
      * time     (time) datetime64[ns] 2000-01-02 2000-01-03 2000-01-04

`first` and `last` methods on groupby objects let you take the first or last
examples from each group along the grouped axis:

    In [5]: array.groupby('time.day').first()
    Out[5]:
    <xray.DataArray (day: 3)>
    array([0, 4, 8])
    Coordinates:
      * day      (day) int64 1 2 3