### PR TITLE
Fix (most) windows issues

### DIFF
--- a/xray/backends/netCDF4_.py
+++ b/xray/backends/netCDF4_.py
@@ -5,7 +5,7 @@ import numpy as np
 from .. import Variable
 from ..conventions import pop_to, cf_encoder
 from ..core import indexing
-from ..core.utils import FrozenOrderedDict, NDArrayMixin
+from ..core.utils import FrozenOrderedDict, NDArrayMixin, close_on_error
 from ..core.pycompat import iteritems, basestring, OrderedDict
 
 from .common import AbstractWritableDataStore
@@ -122,7 +122,8 @@ class NetCDF4DataStore(AbstractWritableDataStore):
         ds = nc4.Dataset(filename, mode=mode, clobber=clobber,
                          diskless=diskless, persist=persist,
                          format=format)
-        self.ds = _nc4_group(ds, group, mode)
+        with close_on_error(ds):
+            self.ds = _nc4_group(ds, group, mode)
         self.format = format
         self._filename = filename
 

--- a/xray/backends/scipy_.py
+++ b/xray/backends/scipy_.py
@@ -34,7 +34,7 @@ class ScipyDataStore(AbstractWritableDataStore):
 
     It only supports the NetCDF3 file-format.
     """
-    def __init__(self, filename_or_obj, mode='r', mmap=None, version=1):
+    def __init__(self, filename_or_obj, mode='r', mmap=None, version=2):
         import scipy
         if mode != 'r' and scipy.__version__ < '0.13':
             warnings.warn('scipy %s detected; '

--- a/xray/core/utils.py
+++ b/xray/core/utils.py
@@ -1,5 +1,6 @@
 """Internal utilties; not for external use
 """
+import contextlib
 import datetime
 import functools
 import itertools
@@ -471,3 +472,15 @@ class NDArrayMixin(object):
 
     def __repr__(self):
         return '%s(array=%r)' % (type(self).__name__, self.array)
+
+
+@contextlib.contextmanager
+def close_on_error(f):
+    """Context manager to ensure that a file opened by xray is closed if an
+    exception is raised before the user sees the file object.
+    """
+    try:
+        yield
+    except Exception:
+        f.close()
+        raise

--- a/xray/test/test_dataarray.py
+++ b/xray/test/test_dataarray.py
@@ -20,7 +20,7 @@ class TestDataArray(TestCase):
 
     def test_repr(self):
         v = Variable(['time', 'x'], [[1, 2, 3], [4, 5, 6]], {'foo': 'bar'})
-        data_array = DataArray(v, {'other': ([], 0)}, name='my_variable')
+        data_array = DataArray(v, {'other': np.int64(0)}, name='my_variable')
         expected = dedent("""\
         <xray.DataArray 'my_variable' (time: 2, x: 3)>
         array([[1, 2, 3],
@@ -381,7 +381,9 @@ class TestDataArray(TestCase):
         self.assertArrayEqual(da.coords['time.dayofyear'], da.values)
 
     def test_coords(self):
-        coords = [Coordinate('x', [-1, -2]), Coordinate('y', [0, 1, 2])]
+        # use int64 to ensure repr() consistency on windows
+        coords = [Coordinate('x', np.array([-1, -2], 'int64')),
+                  Coordinate('y', np.array([0, 1, 2], 'int64'))]
         da = DataArray(np.random.randn(2, 3), coords, name='foo')
 
         self.assertEquals(2, len(da.coords))

--- a/xray/test/test_variable.py
+++ b/xray/test/test_variable.py
@@ -810,7 +810,7 @@ class TestAsCompatibleData(TestCase):
             actual = _as_compatible_data(input_array)
             self.assertArrayEqual(np.asarray(input_array), actual)
             self.assertEqual(NumpyArrayAdapter, type(actual))
-            self.assertEqual(np.dtype(int), actual.dtype)
+            self.assertEqual(np.dtype(np.int64), actual.dtype)
 
     def test_masked_array(self):
         original = np.ma.MaskedArray(np.arange(5))


### PR DESCRIPTION
xref #360

In this change:

- Fix tests that relied on implicit conversion to int64 (Python's int
  on windows is int32).
- Be more careful about always closing files, even in tests.

Not addressed (yet):

- Issues with scipy.io.netcdf_file (#341)