### PR TITLE
Silenced warnings for all-NaN slices when using nan functions from numpy

### DIFF
--- a/doc/whats-new.rst
+++ b/doc/whats-new.rst
@@ -72,9 +72,11 @@ Bug fixes
   ``engine='scipy'`` could still be associated with the file on disk, even
   after closing the file (`issue`:341:). This manifested itself in warnings
   about mmapped arrays and segmentation faults (if the data was accessed).
+- Silenced spurious warnings about all-NaN slices when using nan-aware
+  aggregation methods (`issue`:344:).
 - Dataset aggregations with ``keep_attrs=True`` now preserve attributes on
   data variables, not just the dataset itself.
-- Tests for xray now pass when run on windows. DOUBLE CHECK THIS.
+- Tests for xray now pass when run on Windows. DOUBLE CHECK THIS.
 
 v0.4 (2 March, 2015)
 --------------------

--- a/xray/test/test_ops.py
+++ b/xray/test/test_ops.py
@@ -1,5 +1,6 @@
+import numpy as np
 from numpy import array, nan
-from xray.core.ops import first, last, count
+from xray.core.ops import first, last, count, mean
 
 from . import TestCase
 
@@ -67,3 +68,6 @@ class TestOps(TestCase):
 
         expected = array([[1, 2, 3], [3, 2, 1]])
         self.assertArrayEqual(expected, count(self.x, axis=-1))
+
+    def test_all_nan_arrays(self):
+        assert np.isnan(mean([np.nan, np.nan]))


### PR DESCRIPTION
Fixes #344

These warnings are typically spurious on xray objects.

Note that this does result in a *small* performance penalty for these
functions (e.g., a few percent). This can be avoided by install bottleneck.

CC @jhammon