### PR TITLE
API: new methods {Dataset/DataArray}.swap_dims

### DIFF
--- a/doc/api.rst
+++ b/doc/api.rst
@@ -65,6 +65,7 @@ Dataset contents
    Dataset.copy
    Dataset.merge
    Dataset.rename
+   Dataset.swap_dims
    Dataset.drop
    Dataset.set_coords
    Dataset.reset_coords
@@ -166,6 +167,7 @@ DataArray contents
    :toctree: generated/
 
    DataArray.rename
+   DataArray.swap_dims
    DataArray.drop
    DataArray.reset_coords
    DataArray.copy

--- a/doc/whats-new.rst
+++ b/doc/whats-new.rst
@@ -20,7 +20,7 @@ Enhancements
 
 - New documentation sections on :ref:`time-series` and
   :ref:`combining multiple files`.
-- :py:meth`~xray.Dataset.resample` lets you resample a dataset or data array to
+- :py:meth:`~xray.Dataset.resample` lets you resample a dataset or data array to
   a new temporal resolution. The syntax is the `same as pandas`_, except you
   need to supply the time dimension explicitly:
 
@@ -57,12 +57,22 @@ Enhancements
 
       array.resample('1D', dim='time', how='first')
 
+.. _same as pandas: http://pandas.pydata.org/pandas-docs/stable/timeseries.html#up-and-downsampling
+
+- :py:meth:`~xray.Dataset.swap_dims` allows for easily swapping one dimension
+  out for another:
+
+  .. ipython:: python
+
+       ds = xray.Dataset({'x': range(3), 'y': ('x', list('abc'))})
+       ds
+       ds.swap_dims({'x': 'y'})
+
+  This was possible in earlier versions of xray, but required some contortions.
 - :py:func:`~xray.open_dataset` and :py:meth:`~xray.Dataset.to_netcdf` now
   accept an ``engine`` argument to explicitly select which underlying library
   (netcdf4 or scipy) is used for reading/writing a netCDF file.
 - New documentation section on :ref:`combining multiple files`.
-
-TODO: write full docs on time-series!
 
 .. _same as pandas: http://pandas.pydata.org/pandas-docs/stable/timeseries.html#up-and-downsampling
 

--- a/xray/core/dataarray.py
+++ b/xray/core/dataarray.py
@@ -553,13 +553,23 @@ class DataArray(AbstractArray, BaseDataObject):
     def rename(self, new_name_or_name_dict):
         """Returns a new DataArray with renamed coordinates and/or a new name.
 
-        If the argument is dict-like, it it used as a mapping from old names to
-        new names for dataset variables. Otherwise, use the argument as the new
-        name for this array.
+
+        Parameters
+        ----------
+        new_name_or_name_dict : str or dict-like
+            If the argument is dict-like, it it used as a mapping from old
+            names to new names for coordinates (and/or this array itself).
+            Otherwise, use the argument as the new name for this array.
+
+        Returns
+        -------
+        renamed : DataArray
+            Renamed array or array with renamed coordinates.
 
         See Also
         --------
         Dataset.rename
+        DataArray.swap_dims
         """
         if utils.is_dict_like(new_name_or_name_dict):
             name_dict = new_name_or_name_dict
@@ -569,6 +579,32 @@ class DataArray(AbstractArray, BaseDataObject):
             name_dict = {self.name: new_name}
         renamed_dataset = self._dataset.rename(name_dict)
         return renamed_dataset[new_name]
+
+    def swap_dims(self, dims_dict):
+        """Returns a new DataArray with swapped dimensions.
+
+        Parameters
+        ----------
+        dims_dict : dict-like
+            Dictionary whose keys are current dimension names and whose values
+            are new names. Each value must already be a coordinate on this
+            array.
+        inplace : bool, optional
+            If True, swap dimensions in-place. Otherwise, return a new object.
+
+        Returns
+        -------
+        renamed : Dataset
+            DataArray with swapped dimensions.
+
+        See Also
+        --------
+
+        DataArray.rename
+        Dataset.swap_dims
+        """
+        ds = self._dataset.swap_dims(dims_dict)
+        return self._with_replaced_dataset(ds)
 
     def transpose(self, *dims):
         """Return a new DataArray object with transposed dimensions.

--- a/xray/core/dataarray.py
+++ b/xray/core/dataarray.py
@@ -309,14 +309,8 @@ class DataArray(AbstractArray, BaseDataObject):
 
     @dims.setter
     def dims(self, value):
-        with self._set_new_dataset() as ds:
-            if not len(value) == self.ndim:
-                raise ValueError('%s dimensions supplied but data has ndim=%s'
-                                 % (len(value), self.ndim))
-            name_map = dict(zip(self.dims, value))
-            ds.rename(name_map, inplace=True)
-        if self.name in name_map:
-            self._name = name_map[self.name]
+        raise AttributeError('you cannot assign dims on a DataArray. Use '
+                             '.rename() or .swap_dims() instead.')
 
     def _item_key_to_dict(self, key):
         if utils.is_dict_like(key):

--- a/xray/core/variable.py
+++ b/xray/core/variable.py
@@ -332,6 +332,11 @@ class Variable(common.AbstractArray):
                 "replacement values must match the Variable's shape")
         self._data = values
 
+    def to_variable(self):
+        """Return this variable as a base xray.Variable"""
+        return Variable(self.dims, self._data, self._attrs,
+                        encoding=self._encoding, fastpath=True)
+
     def to_coord(self):
         """Return this variable as an xray.Coordinate"""
         return Coordinate(self.dims, self._data, self._attrs,

--- a/xray/test/test_dataarray.py
+++ b/xray/test/test_dataarray.py
@@ -69,13 +69,8 @@ class TestDataArray(TestCase):
         arr = self.dv
         self.assertEqual(arr.dims, ('x', 'y'))
 
-        arr.dims = ('w', 'z')
-        self.assertEqual(arr.dims, ('w', 'z'))
-
-        x = Dataset({'x': ('x', np.arange(5))})['x']
-        x.dims = ('y',)
-        self.assertEqual(x.dims, ('y',))
-        self.assertEqual(x.name, 'y')
+        with self.assertRaisesRegexp(AttributeError, 'you cannot assign'):
+            arr.dims = ('w', 'z')
 
     def test_encoding(self):
         expected = {'foo': 'bar'}

--- a/xray/test/test_dataarray.py
+++ b/xray/test/test_dataarray.py
@@ -513,6 +513,14 @@ class TestDataArray(TestCase):
             renamed.to_dataset(), self.ds.rename({'foo': 'bar'}))
         self.assertEqual(renamed.name, 'bar')
 
+    def test_swap_dims(self):
+        array = DataArray(np.random.randn(3), {'y': ('x', list('abc'))}, 'x')
+        expected = DataArray(array.values,
+                             {'y': list('abc'), 'x': ('y', range(3))},
+                             dims='y')
+        actual = array.swap_dims({'x': 'y'})
+        self.assertDataArrayIdentical(expected, actual)
+
     def test_dataset_getitem(self):
         dv = self.ds['foo']
         self.assertDataArrayIdentical(dv, self.dv)


### PR DESCRIPTION
Fixes #276

Exmaple usage:

	In [8]: ds = xray.Dataset({'x': range(3), 'y': ('x', list('abc'))})

	In [9]: ds
	Out[9]:
	<xray.Dataset>
	Dimensions:  (x: 3)
	Coordinates:
	  * x        (x) int64 0 1 2
	Data variables:
	    y        (x) |S1 'a' 'b' 'c'

	In [10]: ds.swap_dims({'x': 'y'})
	Out[10]:
	<xray.Dataset>
	Dimensions:  (y: 3)
	Coordinates:
	  * y        (y) |S1 'a' 'b' 'c'
	    x        (y) int64 0 1 2
	Data variables:
	    *empty*

This is a slightly more verbose API than strictly necessary, because the new
dimension names must be along existing dimensions (e.g., we could spell this
`ds.set_dims(['y'])`). But I still think it's a good idea, for two reasons:

1. It's more explicit. Users control know which dimensions are being swapped.
2. It opens up the possibility of specifying new dimensions with dictionary
   like syntax, e.g., `ds.swap_dims('x': ('y', list('abc')))`

CC @aykuznetsova