### PR TITLE
ENH: fillna method for Dataset, DataArray and GroupBy objects

### DIFF
--- a/doc/api-hidden.rst
+++ b/doc/api-hidden.rst
@@ -24,6 +24,11 @@
    Dataset.notnull
    Dataset.count
    Dataset.dropna
+   Dataset.fillna
+
+   core.groupby.DatasetGroupBy.first
+   core.groupby.DatasetGroupBy.last
+   core.groupby.DatasetGroupBy.fillna
 
    Dataset.argsort
    Dataset.clip
@@ -56,6 +61,11 @@
    DataArray.notnull
    DataArray.count
    DataArray.dropna
+   DataArray.fillna
+
+   core.groupby.DataArrayGroupBy.first
+   core.groupby.DataArrayGroupBy.last
+   core.groupby.DataArrayGroupBy.fillna
 
    DataArray.argsort
    DataArray.clip

--- a/doc/api.rst
+++ b/doc/api.rst
@@ -124,6 +124,7 @@ Computation
 :py:attr:`~Dataset.notnull`
 :py:attr:`~Dataset.count`
 :py:attr:`~Dataset.dropna`
+:py:attr:`~Dataset.fillna`
 
 **ndarray methods**:
 :py:attr:`~Dataset.argsort`
@@ -132,6 +133,11 @@ Computation
 :py:attr:`~Dataset.conjugate`
 :py:attr:`~Dataset.round`
 :py:attr:`~Dataset.T`
+
+**Grouped operations**:
+:py:attr:`~core.groupby.DatasetGroupBy.first`
+:py:attr:`~core.groupby.DatasetGroupBy.last`
+:py:attr:`~core.groupby.DatasetGroupBy.fillna`
 
 DataArray
 =========
@@ -223,6 +229,7 @@ Computation
 :py:attr:`~DataArray.notnull`
 :py:attr:`~DataArray.count`
 :py:attr:`~DataArray.dropna`
+:py:attr:`~DataArray.fillna`
 
 **ndarray methods**:
 :py:attr:`~DataArray.argsort`
@@ -232,6 +239,11 @@ Computation
 :py:attr:`~DataArray.searchsorted`
 :py:attr:`~DataArray.round`
 :py:attr:`~DataArray.T`
+
+**Grouped operations**:
+:py:attr:`~core.groupby.DataArrayGroupBy.first`
+:py:attr:`~core.groupby.DataArrayGroupBy.last`
+:py:attr:`~core.groupby.DataArrayGroupBy.fillna`
 
 Comparisons
 -----------

--- a/doc/computation.rst
+++ b/doc/computation.rst
@@ -50,9 +50,9 @@ Missing values
 ==============
 
 xray objects borrow the :py:meth:`~xray.DataArray.isnull`,
-:py:meth:`~xray.DataArray.notnull`, :py:meth:`~xray.DataArray.count` and
-:py:meth:`~xray.DataArray.dropna` methods for working with missing data from
-pandas:
+:py:meth:`~xray.DataArray.notnull`, :py:meth:`~xray.DataArray.count`,
+:py:meth:`~xray.DataArray.dropna` and :py:meth:`~xray.DataArray.fillna` methods
+for working with missing data from pandas:
 
 .. ipython:: python
 
@@ -61,6 +61,7 @@ pandas:
     x.notnull()
     x.count()
     x.dropna(dim='x')
+    x.fillna(-1)
 
 Like pandas, xray uses the float value ``np.nan`` (not-a-number) to represent
 missing values.

--- a/doc/examples/weather-data.rst
+++ b/doc/examples/weather-data.rst
@@ -87,3 +87,21 @@ not show any seasonal cycle.
     @savefig examples_anomalies_plot.png
     anomalies.mean('location').to_dataframe()[['tmin', 'tmax']].plot()
 
+.. _fill with climatology:
+
+Fill missing values with climatology
+------------------------------------
+
+The :py:func:`~xray.Dataset.fillna` method on grouped objects lets you easily
+fill missing values by group:
+
+.. ipython:: python
+
+    some_missing = ds.tmin.sel(time=ds['time.dayofweek'] > 3).reindex_like(ds)
+    filled = some_missing.groupby('time.month').fillna(climatology.tmin)
+
+    both = xray.Dataset({'some_missing': some_missing, 'filled': filled})
+    both
+
+    @savefig examples_filled.png
+    both.sel(time='2000').mean('location').reset_coords(drop=True).to_dataframe().plot()

--- a/doc/io.rst
+++ b/doc/io.rst
@@ -117,13 +117,6 @@ Datasets have a :py:meth:`~xray.Dataset.close` method to close the associated
 netCDF file. However, it's often cleaner to use a ``with`` statement:
 
 .. ipython:: python
-    :suppress:
-
-    ds_disk.close()
-    import os
-    os.remove('saved_on_disk.nc')
-
-.. ipython:: python
 
     # this automatically closes the dataset after use
     with xray.open_dataset('saved_on_disk.nc') as ds:
@@ -168,6 +161,13 @@ serializes objects, by viewing and manipulating the
      'source': 'saved_on_disk.nc',
      'units': u'days since 2000-01-01 00:00:00',
      'zlib': False}
+
+.. ipython:: python
+    :suppress:
+
+    ds_disk.close()
+    import os
+    os.remove('saved_on_disk.nc')
 
 OPeNDAP
 -------

--- a/doc/whats-new.rst
+++ b/doc/whats-new.rst
@@ -9,6 +9,25 @@ What's New
     import xray
     np.random.seed(123456)
 
+v0.4.2 (unreleased)
+-------------------
+
+Enhancements
+~~~~~~~~~~~~
+
+- New :py:meth:`~xray.Dataset.fillna` to fill missing values, modeled off the
+  pandas method of the same name:
+
+  .. ipython:: python
+
+      array = xray.DataArray([np.nan, 1, np.nan, 3], dims='x')
+      array.fillna(0)
+
+  ``fillna`` works on both ``Dataset`` and ``DataArray`` objects, and uses
+  index based alignment and broadcasting like standard binary operations. It
+  also can be applied by group, as illustrated in
+  :ref:`fill with climatology`.
+
 v0.4.1 (18 March 2015)
 ----------------------
 

--- a/doc/why-xray.rst
+++ b/doc/why-xray.rst
@@ -1,5 +1,5 @@
-Why xray?
-=========
+Introduction: Why xray?
+=======================
 
 Features
 --------

--- a/xray/core/dataarray.py
+++ b/xray/core/dataarray.py
@@ -120,7 +120,7 @@ class DataArray(AbstractArray, BaseDataObject):
     attrs : OrderedDict
         Dictionary for holding arbitrary metadata.
     """
-    groupby_cls = groupby.ArrayGroupBy
+    groupby_cls = groupby.DataArrayGroupBy
 
     def __init__(self, data, coords=None, dims=None, name=None,
                  attrs=None, encoding=None):
@@ -701,6 +701,24 @@ class DataArray(AbstractArray, BaseDataObject):
         return self._with_replaced_dataset(ds)
 
     def fillna(self, value):
+        """Fill missing values in this object.
+
+        This operation follows the normal broadcasting and alignment rules that
+        xray uses for binary arithmetic, except the result is aligned to this
+        object (``join='left'``) instead of aligned to the intersection of
+        index coordinates (``join='inner'``).
+
+        Parameters
+        ----------
+        value : scalar, ndarray or DataArray
+            Used to fill all matching missing values in this array. If the
+            argument is a DataArray, it is first aligned with (reindexed to)
+            this array.
+
+        Returns
+        -------
+        DataArray
+        """
         if utils.is_dict_like(value):
             raise TypeError('cannot provide fill value as a dictionary with '
                             'fillna on a DataArray')

--- a/xray/core/dataarray.py
+++ b/xray/core/dataarray.py
@@ -700,6 +700,12 @@ class DataArray(AbstractArray, BaseDataObject):
         ds = self._dataset.dropna(dim, how=how, thresh=thresh)
         return self._with_replaced_dataset(ds)
 
+    def fillna(self, value):
+        if utils.is_dict_like(value):
+            raise TypeError('cannot provide fill value as a dictionary with '
+                            'fillna on a DataArray')
+        return self._fillna(value)
+
     def reduce(self, func, dim=None, axis=None, keep_attrs=False, **kwargs):
         """Reduce this array by applying `func` along some dimension(s).
 

--- a/xray/core/dataarray.py
+++ b/xray/core/dataarray.py
@@ -930,13 +930,13 @@ class DataArray(AbstractArray, BaseDataObject):
         return func
 
     @staticmethod
-    def _binary_op(f, reflexive=False):
+    def _binary_op(f, reflexive=False, join='inner', **ignored_kwargs):
         @functools.wraps(f)
         def func(self, other):
             if isinstance(other, (Dataset, groupby.GroupBy)):
                 return NotImplemented
             if hasattr(other, 'indexes'):
-                self, other = align(self, other, join='inner', copy=False)
+                self, other = align(self, other, join=join, copy=False)
                 empty_indexes = [d for d, s in zip(self.dims, self.shape)
                                  if s == 0]
                 if empty_indexes:

--- a/xray/core/dataset.py
+++ b/xray/core/dataset.py
@@ -1576,6 +1576,9 @@ class Dataset(Mapping, ImplementsDatasetReduce, BaseDataObject):
 
         return self.isel(**{dim: mask})
 
+    def fillna(self, value):
+        return self._fillna(value)
+
     def reduce(self, func, dim=None, keep_attrs=False, numeric_only=False,
                **kwargs):
         """Reduce this dataset by applying `func` along some dimension(s).

--- a/xray/core/groupby.py
+++ b/xray/core/groupby.py
@@ -153,7 +153,7 @@ class GroupBy(object):
         return concat_dim, indexers
 
     @staticmethod
-    def _binary_op(f, reflexive=False):
+    def _binary_op(f, reflexive=False, **ignored_kwargs):
         @functools.wraps(f)
         def func(self, other):
             g = f if not reflexive else lambda x, y: f(y, x)

--- a/xray/core/groupby.py
+++ b/xray/core/groupby.py
@@ -181,6 +181,9 @@ class GroupBy(object):
             combined = combined.reindex(**indexers)
         return combined
 
+    def fillna(self, value):
+        return self._fillna(value)
+
     def _first_or_last(self, op, skipna, keep_attrs):
         if isinstance(self.group_indices[0], (int, np.integer)):
             # NB. this is currently only used for reductions along an existing

--- a/xray/core/ops.py
+++ b/xray/core/ops.py
@@ -298,7 +298,7 @@ def inject_binary_ops(cls, inplace=False):
     # patch in fillna
     f = _func_slash_method_wrapper(fillna)
     method = cls._binary_op(f, join='left', drop_missing_vars=False)
-    setattr(cls, 'fillna', method)
+    setattr(cls, '_fillna', method)
 
     for name in NUM_BINARY_OPS:
         # only numeric operations have in-place and reflexive variants

--- a/xray/core/ops.py
+++ b/xray/core/ops.py
@@ -102,6 +102,13 @@ def count(values, axis=None):
     return np.sum(~pd.isnull(values), axis=axis)
 
 
+def fillna(values, other):
+    """Fill missing values in this object with values from the other object.
+    Follows normal broadcasting and alignment rules.
+    """
+    return np.where(pd.isnull(values), other, values)
+
+
 @contextlib.contextmanager
 def _ignore_warnings_if(condition):
     if condition:
@@ -284,8 +291,15 @@ def op(name):
 def inject_binary_ops(cls, inplace=False):
     for name in CMP_BINARY_OPS + NUM_BINARY_OPS:
         setattr(cls, op_str(name), cls._binary_op(op(name)))
+
     for name, f in [('eq', array_eq), ('ne', array_ne)]:
         setattr(cls, op_str(name), cls._binary_op(f))
+
+    # patch in fillna
+    f = _func_slash_method_wrapper(fillna)
+    method = cls._binary_op(f, join='left', drop_missing_vars=False)
+    setattr(cls, 'fillna', method)
+
     for name in NUM_BINARY_OPS:
         # only numeric operations have in-place and reflexive variants
         setattr(cls, op_str('r' + name),

--- a/xray/core/variable.py
+++ b/xray/core/variable.py
@@ -578,6 +578,9 @@ class Variable(common.AbstractArray):
                                 self._encoding, fastpath=True)
         return expanded_var.transpose(*dims)
 
+    def fillna(self, value):
+        return self._fillna(value)
+
     def reduce(self, func, dim=None, axis=None, keep_attrs=False,
                **kwargs):
         """Reduce this array by applying `func` along some dimension(s).

--- a/xray/core/variable.py
+++ b/xray/core/variable.py
@@ -784,7 +784,7 @@ class Variable(common.AbstractArray):
         return func
 
     @staticmethod
-    def _binary_op(f, reflexive=False):
+    def _binary_op(f, reflexive=False, **ignored_kwargs):
         @functools.wraps(f)
         def func(self, other):
             if isinstance(other, (xray.DataArray, xray.Dataset)):


### PR DESCRIPTION
This is a new method for Dataset, DataArray and GroupBy objects. For the most part, it follows standard broadcasting and alignment rules for binary operations.

Example usage
-------------

Setup:

    In [1]: import xray

    In [2]: import pandas as pd

    In [3]: import numpy as np

    In [4]: array = xray.DataArray(np.arange(75.0), [('time', pd.date_range('2000-01-01', periods=75, freq='5D'))])

    In [5]: array[::3] = np.nan

    In [6]: array
    Out[6]:
    <xray.DataArray (time: 75)>
    array([ nan,   1.,   2.,  nan,   4.,   5.,  nan,   7.,   8.,  nan,  10.,
            11.,  nan,  13.,  14.,  nan,  16.,  17.,  nan,  19.,  20.,  nan,
            22.,  23.,  nan,  25.,  26.,  nan,  28.,  29.,  nan,  31.,  32.,
            nan,  34.,  35.,  nan,  37.,  38.,  nan,  40.,  41.,  nan,  43.,
            44.,  nan,  46.,  47.,  nan,  49.,  50.,  nan,  52.,  53.,  nan,
            55.,  56.,  nan,  58.,  59.,  nan,  61.,  62.,  nan,  64.,  65.,
            nan,  67.,  68.,  nan,  70.,  71.,  nan,  73.,  74.])
    Coordinates:
      * time     (time) datetime64[ns] 2000-01-01 2000-01-06 2000-01-11 2000-01-16 ...

Simple example:

    In [7]: array.fillna(0)
    Out[7]:
    <xray.DataArray (time: 75)>
    array([  0.,   1.,   2.,   0.,   4.,   5.,   0.,   7.,   8.,   0.,  10.,
            11.,   0.,  13.,  14.,   0.,  16.,  17.,   0.,  19.,  20.,   0.,
            22.,  23.,   0.,  25.,  26.,   0.,  28.,  29.,   0.,  31.,  32.,
             0.,  34.,  35.,   0.,  37.,  38.,   0.,  40.,  41.,   0.,  43.,
            44.,   0.,  46.,  47.,   0.,  49.,  50.,   0.,  52.,  53.,   0.,
            55.,  56.,   0.,  58.,  59.,   0.,  61.,  62.,   0.,  64.,  65.,
             0.,  67.,  68.,   0.,  70.,  71.,   0.,  73.,  74.])
    Coordinates:
      * time     (time) datetime64[ns] 2000-01-01 2000-01-06 2000-01-11 2000-01-16 ...

Fill missing values with average for that month:

    In [8]: g = array.groupby('time.month')

    In [9]: g.fillna(g.mean('time'))
    Out[9]:
    <xray.DataArray (time: 75)>
    array([ 17.2,   1. ,   2. ,  17.2,   4. ,   5. ,  17.2,   7. ,   8. ,
             9. ,  10. ,  11. ,  15. ,  13. ,  14. ,  15. ,  16. ,  17. ,
            15. ,  19. ,  20. ,  21. ,  22. ,  23. ,  21. ,  25. ,  26. ,
            27. ,  28. ,  29. ,  27. ,  31. ,  32. ,  33. ,  34. ,  35. ,
            33. ,  37. ,  38. ,  39. ,  40. ,  41. ,  39. ,  43. ,  44. ,
            45. ,  46. ,  47. ,  45. ,  49. ,  50. ,  51. ,  52. ,  53. ,
            51. ,  55. ,  56. ,  57. ,  58. ,  59. ,  57. ,  61. ,  62. ,
            63. ,  64. ,  65. ,  63. ,  67. ,  68. ,  69.8,  70. ,  71. ,
            69.8,  73. ,  74. ])
    Coordinates:
      * time     (time) datetime64[ns] 2000-01-01 2000-01-06 2000-01-11 2000-01-16 ...
        month    (time) int32 1 1 1 1 1 1 1 2 2 2 2 2 3 3 3 3 3 3 3 4 4 4 4 4 4 5 5 5 5 5 5 6 6 6 ...

CC @nicolasfauchereau