### PR TITLE
ENH: Add Dataset.assign and .assign_coords

### DIFF
--- a/doc/api-hidden.rst
+++ b/doc/api-hidden.rst
@@ -26,6 +26,8 @@
    Dataset.dropna
    Dataset.fillna
 
+   core.groupby.DatasetGroupBy.assign
+   core.groupby.DatasetGroupBy.assign_coords
    core.groupby.DatasetGroupBy.first
    core.groupby.DatasetGroupBy.last
    core.groupby.DatasetGroupBy.fillna
@@ -63,6 +65,7 @@
    DataArray.dropna
    DataArray.fillna
 
+   core.groupby.DataArrayGroupBy.assign_coords
    core.groupby.DataArrayGroupBy.first
    core.groupby.DataArrayGroupBy.last
    core.groupby.DataArrayGroupBy.fillna

--- a/doc/api.rst
+++ b/doc/api.rst
@@ -63,6 +63,8 @@ Dataset contents
    :toctree: generated/
 
    Dataset.copy
+   Dataset.assign
+   Dataset.assign_coords
    Dataset.merge
    Dataset.rename
    Dataset.swap_dims
@@ -135,6 +137,8 @@ Computation
 :py:attr:`~Dataset.T`
 
 **Grouped operations**:
+:py:attr:`~core.groupby.DatasetGroupBy.assign`
+:py:attr:`~core.groupby.DatasetGroupBy.assign_coords`
 :py:attr:`~core.groupby.DatasetGroupBy.first`
 :py:attr:`~core.groupby.DatasetGroupBy.last`
 :py:attr:`~core.groupby.DatasetGroupBy.fillna`
@@ -172,6 +176,7 @@ DataArray contents
 .. autosummary::
    :toctree: generated/
 
+   DataArray.assign_coords
    DataArray.rename
    DataArray.swap_dims
    DataArray.drop
@@ -241,6 +246,7 @@ Computation
 :py:attr:`~DataArray.T`
 
 **Grouped operations**:
+:py:attr:`~core.groupby.DataArrayGroupBy.assign_coords`
 :py:attr:`~core.groupby.DataArrayGroupBy.first`
 :py:attr:`~core.groupby.DataArrayGroupBy.last`
 :py:attr:`~core.groupby.DataArrayGroupBy.fillna`

--- a/doc/whats-new.rst
+++ b/doc/whats-new.rst
@@ -27,6 +27,18 @@ Enhancements
   index based alignment and broadcasting like standard binary operations. It
   also can be applied by group, as illustrated in
   :ref:`fill with climatology`.
+- New :py:meth:`~xray.Dataset.assign` and :py:meth:`~xray.Dataset.assign_coords`
+  methods patterned off the new :py:meth:`DataFrame.assign <pandas.DataFrame.assign>`
+  method in pandas:
+
+  .. ipython:: python
+
+      ds = xray.Dataset({'y': ('x', [1, 2, 3])})
+      ds.assign(z = lambda x: x.y ** 2)
+      ds.assign_coords(z = ('x', ['a', 'b', 'c']))
+
+  These methods return a new Dataset (or DataArray) with updated data or
+  coordinate variables.
 
 v0.4.1 (18 March 2015)
 ----------------------

--- a/doc/why-xray.rst
+++ b/doc/why-xray.rst
@@ -1,5 +1,5 @@
-Introduction: Why xray?
-=======================
+Overview: Why xray?
+===================
 
 Features
 --------

--- a/xray/core/coordinates.py
+++ b/xray/core/coordinates.py
@@ -49,6 +49,9 @@ class AbstractCoordinates(Mapping):
         else:
             raise KeyError(key)
 
+    def __setitem__(self, key, value):
+        self.update({key: value})
+
     def __iter__(self):
         # needs to be in the same order as the dataset variables
         for k in self._dataset._variables:
@@ -163,9 +166,9 @@ class DatasetCoordinates(AbstractCoordinates):
     def __init__(self, dataset):
         self._dataset = dataset
 
-    def __setitem__(self, key, value):
-        self._dataset[key] = value
-        self._names.add(key)
+    def update(self, other):
+        self._dataset.update(other)
+        self._names.update(other.keys())
 
 
 class DataArrayCoordinates(AbstractCoordinates):
@@ -179,11 +182,10 @@ class DataArrayCoordinates(AbstractCoordinates):
         self._dataarray = dataarray
         self._dataset = dataarray._dataset
 
-    def __setitem__(self, key, value):
+    def update(self, other):
         with self._dataarray._set_new_dataset() as ds:
-            ds.coords[key] = value
-            bad_dims = [d for d in ds._variables[key].dims
-                        if d not in self.dims]
+            ds.coords.update(other)
+            bad_dims = [d for d in ds.dims if d not in self.dims]
             if bad_dims:
                 raise ValueError('DataArray does not include all coordinate '
                                  'dimensions: %s' % bad_dims)

--- a/xray/core/groupby.py
+++ b/xray/core/groupby.py
@@ -227,6 +227,15 @@ class GroupBy(object):
         """
         return self._first_or_last(ops.last, skipna, keep_attrs)
 
+    def assign_coords(self, **kwargs):
+        """Assign coordinates by group.
+
+        See also
+        --------
+        Dataset.assign_coords
+        """
+        return self.apply(lambda ds: ds.assign_coords(**kwargs))
+
 
 class DataArrayGroupBy(GroupBy, ImplementsArrayReduce):
     """GroupBy object specialized to grouping DataArray objects
@@ -451,6 +460,15 @@ class DatasetGroupBy(GroupBy, ImplementsDatasetReduce):
         def reduce_dataset(ds):
             return ds.reduce(func, dim, keep_attrs, **kwargs)
         return self.apply(reduce_dataset)
+
+    def assign(self, **kwargs):
+        """Assign data variables by group.
+
+        See also
+        --------
+        Dataset.assign
+        """
+        return self.apply(lambda ds: ds.assign(**kwargs))
 
 ops.inject_reduce_methods(DatasetGroupBy)
 ops.inject_binary_ops(DatasetGroupBy)

--- a/xray/test/test_dataarray.py
+++ b/xray/test/test_dataarray.py
@@ -470,6 +470,18 @@ class TestDataArray(TestCase):
         with self.assertRaisesRegexp(ValueError, 'cannot remove index'):
             data.reset_coords('y')
 
+    def test_assign_coords(self):
+        array = DataArray(10)
+        actual = array.assign_coords(c = 42)
+        expected = DataArray(10, {'c': 42})
+        self.assertDataArrayIdentical(actual, expected)
+
+        array = DataArray([1, 2, 3, 4], {'c': ('x', [0, 0, 1, 1])}, dims='x')
+        actual = array.groupby('c').assign_coords(d = lambda a: a.mean())
+        expected = array.copy()
+        expected.coords['d'] = ('x', [1.5, 1.5, 3.5, 3.5])
+        self.assertDataArrayIdentical(actual, expected)
+
     def test_reindex(self):
         foo = self.dv
         bar = self.dv[:2, :2]


### PR DESCRIPTION
Fixes #314

Based off the new pandas method of the same name.

An example:

	In [3]: ds = xray.Dataset({'y': ('x', [1, 2, 3])})

	In [4]: ds.assign(z = lambda x: x.y ** 2)
	Out[4]:
	<xray.Dataset>
	Dimensions:  (x: 3)
	Coordinates:
	  * x        (x) int64 0 1 2
	Data variables:
	    y        (x) int64 1 2 3
	    z        (x) int64 1 4 9