### PR TITLE
Rename .load_data() to the more succinct .load()

### DIFF
--- a/doc/api.rst
+++ b/doc/api.rst
@@ -344,8 +344,8 @@ Dataset methods
    Dataset.to_dataframe
    Dataset.from_dataframe
    Dataset.close
-   Dataset.load_data
-   Dataset.reblock
+   Dataset.load
+   Dataset.chunk
 
 DataArray methods
 -----------------
@@ -361,8 +361,8 @@ DataArray methods
    DataArray.to_cdms2
    DataArray.from_series
    DataArray.from_cdms2
-   DataArray.load_data
-   DataArray.reblock
+   DataArray.load
+   DataArray.chunk
 
 Backends (experimental)
 -----------------------

--- a/doc/dask.rst
+++ b/doc/dask.rst
@@ -9,13 +9,13 @@ to support streaming computation on datasets that don't fit into memory.
 TOOD: briefly summarize the dask data model.
 
 To create a dataset filled with dask arrays, either use :py:func:`~xray.open_mfdataset`
-to open a collection of files from disk or the :py:meth:`~xray.Dataset.chunk_data`
+to open a collection of files from disk or the :py:meth:`~xray.Dataset.chunk`
 method to convert an existing dataset.
 
 In the dask computation work, actual calculations are only performed on
 demand, when computed data is requested. Printing a ``Dataset`` will show the
 first few computed values. To load a dataset from dask array entirely into memory as
-numpy arrays, use the :py:meth:`~xray.Dataset.load_data` method. You can also write
+numpy arrays, use the :py:meth:`~xray.Dataset.load` method. You can also write
 datasets too big to fit into memory directly to disk with
 :py:meth:`~xray.Dataset.to_netcdf`.
 
@@ -29,8 +29,8 @@ concatenating and grouped operations) have been extended to work automatically
 with dask arrays. However, there are a few caveats:
 
 1. Operations between dask arrays with different ``chunks`` or between dask arrays
-   and numpy arrays are not currently supported by dask. You'll need to use ``chunk_data``
-   to manual coerce input into dask arrays with the same ``chunks``.
+   and numpy arrays are not currently supported by dask. You'll need to use the
+   ``chunk`` method to manually coerce input into dask arrays with the same ``chunks``.
 2. NumPy ufuncs like ``np.sin`` currently only work on eagerly evaluated arrays. We've
    provided replacements that also work on all xray objects, including those that
    store lazy dask arrays, in the ``xray.ufuncs`` module::

--- a/doc/io.rst
+++ b/doc/io.rst
@@ -111,7 +111,7 @@ is modified: the original file on disk is never touched.
     xray's lazy loading of remote or on-disk datasets is often but not always
     desirable. Before performing computationally intense operations, it is
     usually a good idea to load a dataset entirely into memory by invoking the
-    :py:meth:`~xray.Dataset.load_data` method.
+    :py:meth:`~xray.Dataset.load` method.
 
 Datasets have a :py:meth:`~xray.Dataset.close` method to close the associated
 netCDF file. However, it's often cleaner to use a ``with`` statement:
@@ -326,7 +326,7 @@ deficiencies::
                     ds = transform_func(ds)
                 # load all data from the transformed dataset, to ensure we can
                 # use it after closing each original file
-                ds.load_data()
+                ds.load()
                 return ds
 
         paths = sorted(glob(files))

--- a/doc/whats-new.rst
+++ b/doc/whats-new.rst
@@ -88,6 +88,12 @@ Enhancements
   These methods return a new Dataset (or DataArray) with updated data or
   coordinate variables.
 
+Deprecations
+~~~~~~~~~~~~
+
+- The method ``load_data()`` has been renamed to the more succinct
+  :py:meth:`~xray.Dataset.load`.
+
 v0.4.1 (18 March 2015)
 ----------------------
 

--- a/xray/backends/api.py
+++ b/xray/backends/api.py
@@ -102,7 +102,7 @@ def open_dataset(filename_or_obj, group=None, decode_cf=True,
             store, mask_and_scale=mask_and_scale, decode_times=decode_times,
             concat_characters=concat_characters, decode_coords=decode_coords)
         if chunks is not None:
-            ds = ds.chunk_data(chunks)
+            ds = ds.chunk(chunks)
         return ds
 
     if isinstance(filename_or_obj, backends.AbstractDataStore):
@@ -195,7 +195,7 @@ def open_mfdataset(paths, chunks=None, concat_dim=None, **kwargs):
         raise IOError('no files to open')
     datasets = [open_dataset(p, **kwargs) for p in paths]
     file_objs = [ds._file_obj for ds in datasets]
-    datasets = [ds.chunk_data(chunks) for ds in datasets]
+    datasets = [ds.chunk(chunks) for ds in datasets]
     combined = auto_combine(datasets, concat_dim=concat_dim)
     combined._file_obj = _MultiFileCloser(file_objs)
     return combined

--- a/xray/core/dataarray.py
+++ b/xray/core/dataarray.py
@@ -1,5 +1,6 @@
 import contextlib
 import functools
+import warnings
 
 import pandas as pd
 
@@ -418,7 +419,7 @@ class DataArray(AbstractArray, BaseDataObject):
         ds = self._dataset.reset_coords(names, drop, inplace)
         return ds[self.name] if drop else ds
 
-    def load_data(self):
+    def load(self):
         """Manually trigger loading of this array's data from disk or a
         remote source into memory and return this array.
 
@@ -427,8 +428,14 @@ class DataArray(AbstractArray, BaseDataObject):
         load data automatically. However, this method can be necessary when
         working with many file objects on disk.
         """
-        self._dataset.load_data()
+        self._dataset.load()
         return self
+
+    def load_data(self):  # pragma: no cover
+        warnings.warn('the DataArray method `load_data` has been deprecated; '
+                      'use `load` instead',
+                      FutureWarning, stacklevel=2)
+        return self.load()
 
     def copy(self, deep=True):
         """Returns a copy of this array.
@@ -458,7 +465,7 @@ class DataArray(AbstractArray, BaseDataObject):
         """
         return self.variable.chunks
 
-    def chunk_data(self, chunks=None):
+    def chunk(self, chunks=None):
         """Coerce this array's data into a dask arrays with the given chunks.
 
         If this variable is a non-dask array, it will be converted to dask
@@ -482,7 +489,7 @@ class DataArray(AbstractArray, BaseDataObject):
         if isinstance(chunks, (list, tuple)):
             chunks = dict(zip(self.dims, chunks))
 
-        ds = self._dataset.chunk_data(chunks)
+        ds = self._dataset.chunk(chunks)
         return self._with_replaced_dataset(ds)
 
     def isel(self, **indexers):

--- a/xray/core/variable.py
+++ b/xray/core/variable.py
@@ -238,7 +238,7 @@ class Variable(common.AbstractArray, utils.NdimSizeLenMixin):
     def _indexable_data(self):
         return orthogonally_indexable(self._data)
 
-    def load_data(self):
+    def load(self):
         """Manually trigger loading of this variable's data from disk or a
         remote source into memory and return this variable.
 
@@ -248,6 +248,12 @@ class Variable(common.AbstractArray, utils.NdimSizeLenMixin):
         """
         self._data_cached()
         return self
+
+    def load_data(self):  # pragma: no cover
+        warnings.warn('the Variable method `load_data` has been deprecated; '
+                      'use `load` instead',
+                      FutureWarning, stacklevel=2)
+        return self.load()
 
     def __getstate__(self):
         """Always cache data as an in-memory array before pickling"""
@@ -407,7 +413,7 @@ class Variable(common.AbstractArray, utils.NdimSizeLenMixin):
 
     _array_counter = itertools.count()
 
-    def chunk_data(self, chunks=None, name=''):
+    def chunk(self, chunks=None, name=''):
         """Coerce this array's data into a dask arrays with the given chunks.
 
         If this variable is a non-dask array, it will be converted to dask
@@ -423,6 +429,9 @@ class Variable(common.AbstractArray, utils.NdimSizeLenMixin):
         chunks : int, tuple or dict, optional
             Chunk sizes along each dimension, e.g., ``5``, ``(5, 5)`` or
             ``{'x': 5, 'y': 5}``.
+        name : str, optional
+            Used to generate the name for this array in the internal dask
+            graph. Does not need not be unique.
 
         Returns
         -------

--- a/xray/test/test_backends.py
+++ b/xray/test/test_backends.py
@@ -80,7 +80,7 @@ class DatasetIOTestCases(object):
         with self.roundtrip(expected) as actual:
             self.assertDatasetAllClose(expected, actual)
 
-    def test_load_data(self):
+    def test_load(self):
         expected = create_test_data()
 
         @contextlib.contextmanager
@@ -102,14 +102,14 @@ class DatasetIOTestCases(object):
                 pass
 
         with assert_loads() as ds:
-            ds.load_data()
+            ds.load()
 
         with assert_loads(['var1', 'dim1', 'dim2']) as ds:
-            ds['var1'].load_data()
+            ds['var1'].load()
 
         # verify we can read data even after closing the file
         with self.roundtrip(expected) as ds:
-            actual = ds.load_data()
+            actual = ds.load()
         self.assertDatasetAllClose(expected, actual)
 
     def test_roundtrip_None_variable(self):

--- a/xray/test/test_dask.py
+++ b/xray/test/test_dask.py
@@ -68,13 +68,13 @@ class TestVariable(DaskTestCase):
         self.assertEqual(self.data.chunks, v.chunks)
         self.assertArrayEqual(self.values, v)
 
-    def test_chunk_data(self):
+    def test_chunk(self):
         for chunks, expected in [(None, ((2, 2), (2, 2, 2))),
                                  (3, ((3, 1), (3, 3))),
                                  ({'x': 3, 'y': 3}, ((3, 1), (3, 3))),
                                  ({'x': 3}, ((3, 1), (2, 2, 2))),
                                  ({'x': (3, 1)}, ((3, 1), (2, 2, 2)))]:
-            rechunked = self.lazy_var.chunk_data(chunks)
+            rechunked = self.lazy_var.chunk(chunks)
             self.assertEqual(rechunked.chunks, expected)
             self.assertLazyAndIdentical(self.eager_var, rechunked)
 
@@ -231,13 +231,13 @@ class TestDataArrayAndDataset(DaskTestCase):
 
     def test_simultaneous_compute(self):
         ds = Dataset({'foo': ('x', range(5)),
-                      'bar': ('x', range(5))}).chunk_data()
+                      'bar': ('x', range(5))}).chunk()
 
-        count = np.array(0)
+        count = [0]
         def counting_get(*args, **kwargs):
-            count[...] += 1
+            count[0] += 1
             return dask.get(*args, **kwargs)
 
         with dask.set_options(get=counting_get):
-            ds.load_data()
-        self.assertEqual(count, 1)
+            ds.load()
+        self.assertEqual(count[0], 1)

--- a/xray/test/test_dataarray.py
+++ b/xray/test/test_dataarray.py
@@ -334,18 +334,20 @@ class TestDataArray(TestCase):
         self.assertDataArrayIdentical(expected, actual)
 
     @requires_dask
-    def test_chunk_data(self):
+    def test_chunk(self):
         unblocked = DataArray(np.ones((3, 4)))
         self.assertIsNone(unblocked.chunks)
 
-        blocked = unblocked.chunk_data()
+        blocked = unblocked.chunk()
         self.assertEqual(blocked.chunks, ((3,), (4,)))
 
-        blocked = unblocked.chunk_data(chunks=((2, 1), (2, 2)))
+        blocked = unblocked.chunk(chunks=((2, 1), (2, 2)))
         self.assertEqual(blocked.chunks, ((2, 1), (2, 2)))
 
-        blocked = unblocked.chunk_data(chunks=(3, 3))
+        blocked = unblocked.chunk(chunks=(3, 3))
         self.assertEqual(blocked.chunks, ((3,), (3, 1)))
+
+        self.assertIsNone(blocked.load().chunks)
 
     def test_isel(self):
         self.assertDataArrayIdentical(self.dv[0], self.dv.isel(x=0))

--- a/xray/test/test_dataset.py
+++ b/xray/test/test_dataset.py
@@ -245,7 +245,8 @@ class TestDataset(TestCase):
         self.assertNotIn('var1', ds.coords)
         self.assertEqual(len(ds.coords), 5)
 
-        self.assertEqual(Dataset({'x': 1, 'y': [1, 2]}).nbytes, 24)
+        self.assertEqual(Dataset({'x': np.int64(1),
+                                  'y': np.float32([1, 2])}).nbytes, 16)
 
     def test_attr_access(self):
         ds = Dataset({'tmin': ('x', [42], {'units': 'Celcius'})},


### PR DESCRIPTION
Also rename `.chunk_data()` -> `.chunk()` (but nobody is using that, yet).