### PR TITLE
Dataset.to_array and DataArray.to_dataset methods

### DIFF
--- a/doc/api.rst
+++ b/doc/api.rst
@@ -341,6 +341,7 @@ Dataset methods
    open_dataset
    open_mfdataset
    Dataset.to_netcdf
+   Dataset.to_array
    Dataset.to_dataframe
    Dataset.from_dataframe
    Dataset.close

--- a/doc/whats-new.rst
+++ b/doc/whats-new.rst
@@ -63,6 +63,17 @@ Backwards incompatible changes
 Enhancements
 ~~~~~~~~~~~~
 
+- New :py:meth:`~xray.Dataset.to_array` and enhanced
+  :py:meth:`~xray.DataArray.to_dataset` methods make it easy to switch back
+  and forth between arrays and datasets:
+
+  .. ipython:: python
+
+      ds = xray.Dataset({'a': 1, 'b': ('x', [1, 2, 3])},
+                        coords={'c': 42}, attrs={'Conventions': 'None'})
+      ds.to_array()
+      ds.to_array().to_dataset(dim='variables')
+
 - New :py:meth:`~xray.Dataset.fillna` method to fill missing values, modeled
   off the pandas method of the same name:
 

--- a/xray/test/__init__.py
+++ b/xray/test/__init__.py
@@ -1,3 +1,6 @@
+import warnings
+from contextlib import contextmanager
+
 import numpy as np
 from numpy.testing import assert_array_equal
 
@@ -93,6 +96,13 @@ class TestCase(unittest.TestCase):
         # assertItemsEqual
         def assertItemsEqual(self, first, second, msg=None):
             return self.assertCountEqual(first, second, msg)
+
+    @contextmanager
+    def assertWarns(self, message):
+        with warnings.catch_warnings(record=True) as w:
+            warnings.filterwarnings('always', message)
+            yield
+            self.assertTrue(any(message in str(wi.message) for wi in w))
 
     def assertVariableEqual(self, v1, v2):
         assert as_variable(v1).equals(v2), (v1, v2)

--- a/xray/test/test_conventions.py
+++ b/xray/test/test_conventions.py
@@ -262,13 +262,9 @@ class TestDatetime(TestCase):
         dt = nc4.netcdftime.datetime(2001, 2, 29)
         for calendar in ['360_day', 'all_leap', '366_day']:
             num_time = nc4.date2num(dt, units, calendar)
-            with warnings.catch_warnings(record=True) as w:
-                warnings.simplefilter('always')
+            with self.assertWarns('Unable to decode time axis'):
                 actual = conventions.decode_cf_datetime(num_time, units,
                                                         calendar=calendar)
-                self.assertEqual(len(w), 1)
-                self.assertIn('Unable to decode time axis',
-                              str(w[0].message))
             expected = np.asarray(nc4.num2date(num_time, units, calendar))
             print(num_time, calendar, actual, expected)
             self.assertEqual(actual.dtype, np.dtype('O'))

--- a/xray/test/test_dask.py
+++ b/xray/test/test_dask.py
@@ -18,7 +18,7 @@ def _copy_at_variable_level(arg):
     if isinstance(arg, Variable):
         return arg.copy(deep=False)
     elif isinstance(arg, DataArray):
-        ds = arg.to_dataset('__copied__')
+        ds = arg.to_dataset(name='__copied__')
         return _copy_at_variable_level(ds)['__copied__']
     elif isinstance(arg, Dataset):
         ds = arg.copy()
@@ -223,6 +223,13 @@ class TestDataArrayAndDataset(DaskTestCase):
             expected = u.reindex(**kwargs)
             actual = v.reindex(**kwargs)
             self.assertLazyAndAllClose(expected, actual)
+
+    def test_to_dataset_roundtrip(self):
+        u = self.eager_array
+        v = self.lazy_array
+
+        expected = u.assign_coords(x=u['x'].astype(str))
+        self.assertLazyAndIdentical(expected, v.to_dataset('x').to_array('x'))
 
     def test_ufuncs(self):
         u = self.eager_array

--- a/xray/test/test_dataset.py
+++ b/xray/test/test_dataset.py
@@ -1518,6 +1518,20 @@ class TestDataset(TestCase):
         with self.assertRaises(KeyError):
             auto_combine(objs)
 
+    def test_to_array(self):
+        ds = Dataset(OrderedDict([('a', 1), ('b', ('x', [1, 2, 3]))]),
+                     coords={'c': 42}, attrs={'Conventions': 'None'})
+        data = [[1, 1, 1], [1, 2, 3]]
+        coords = {'x': range(3), 'c': 42, 'variables': ['a', 'b']}
+        dims = ('variables', 'x')
+        expected = DataArray(data, coords, dims, attrs=ds.attrs)
+        actual = ds.to_array()
+        self.assertDataArrayIdentical(expected, actual)
+
+        actual = ds.to_array('abc')
+        expected = expected.rename({'variables': 'abc'})
+        self.assertDataArrayIdentical(expected, actual)
+
     def test_to_and_from_dataframe(self):
         x = np.random.randn(10)
         y = np.random.randn(10)


### PR DESCRIPTION
These methods make it easy to switch back and forth between data arrays and datasets:
```
In [4]: ds = xray.Dataset({'a': 1, 'b': ('x', [1, 2, 3])},
   ...:                   coords={'c': 42}, attrs={'Conventions': 'None'})
   ...: 

In [5]: ds.to_array()
Out[5]: 
<xray.DataArray (variables: 2, x: 3)>
array([[1, 1, 1],
       [1, 2, 3]])
Coordinates:
    c          int64 42
  * x          (x) int64 0 1 2
  * variables  (variables) |S1 'a' 'b'
Attributes:
    Conventions: None

In [6]: ds.to_array().to_dataset(dim='variables')
Out[6]: 
<xray.Dataset>
Dimensions:  (x: 3)
Coordinates:
    c        int64 42
  * x        (x) int64 0 1 2
Data variables:
    a        (x) int64 1 1 1
    b        (x) int64 1 2 3
Attributes:
    Conventions: None
```

Fixes #132

CC @IamJeffG 