### PR TITLE
Add robust retry logic when accessing remote datasets

### DIFF
--- a/doc/whats-new.rst
+++ b/doc/whats-new.rst
@@ -98,6 +98,12 @@ Enhancements
 
   These methods return a new Dataset (or DataArray) with updated data or
   coordinate variables.
+- You can now control the underlying backend used for accessing remote
+  datasets (via OPeNDAP) by specifying ``engine='netcdf4'`` or
+  ``engine='pydap'``.
+- Accessing data from remote datasets now has retrying logic (with exponential
+  backoff) that should make it robust to occasional bad responses from DAP
+  servers.
 
 Deprecations
 ~~~~~~~~~~~~

--- a/xray/backends/api.py
+++ b/xray/backends/api.py
@@ -1,22 +1,16 @@
 import sys
 import gzip
-import itertools
-import re
 from glob import glob
 from io import BytesIO
 
-import numpy as np
-
 from .. import backends, conventions
-from ..core.dataset import Dataset
 from ..core.alignment import auto_combine
-from ..core.utils import close_on_error
-from ..core.variable import Variable
+from ..core.utils import close_on_error, is_remote_uri
 from ..core.pycompat import basestring, OrderedDict, range
 
 
 def _get_default_engine(path, allow_remote=False):
-    if allow_remote and re.search('^https?\://', path):  # pragma: no cover
+    if allow_remote and is_remote_uri(path):  # pragma: no cover
         try:
             import netCDF4
             engine = 'netcdf4'

--- a/xray/backends/common.py
+++ b/xray/backends/common.py
@@ -9,6 +9,7 @@ from ..core.utils import FrozenOrderedDict
 from ..core.pycompat import iteritems, dask_array_type
 from ..core.variable import Coordinate
 
+# Create a logger object, but don't add any handlers. Leave that to user code.
 logger = logging.getLogger(__name__)
 
 
@@ -51,6 +52,9 @@ def robust_getitem(array, key, catch=Exception, max_retries=6,
     """
     Robustly index an array, using retry logic with exponential backoff if any
     of the errors ``catch`` are raised. The initial_delay is measured in ms.
+
+    With the default settings, the maximum delay will be in the range of 32-64
+    seconds.
     """
     assert max_retries >= 0
     for n in range(max_retries + 1):

--- a/xray/backends/netCDF4_.py
+++ b/xray/backends/netCDF4_.py
@@ -38,7 +38,7 @@ class NetCDF4ArrayWrapper(NDArrayMixin):
         return dtype
 
     def __getitem__(self, key):
-        if self.is_remote:
+        if self.is_remote:  # pragma: no cover
             getitem = partial(robust_getitem, catch=RuntimeError)
         else:
             getitem = operator.getitem

--- a/xray/backends/pydap_.py
+++ b/xray/backends/pydap_.py
@@ -4,7 +4,7 @@ from .. import Variable
 from ..core.utils import FrozenOrderedDict, Frozen, NDArrayMixin
 from ..core import indexing
 
-from .common import AbstractDataStore
+from .common import AbstractDataStore, robust_getitem
 
 
 class PydapArrayWrapper(NDArrayMixin):
@@ -32,7 +32,7 @@ class PydapArrayWrapper(NDArrayMixin):
         # pull the data from the array attribute if possible, to avoid
         # downloading coordinate data twice
         array = getattr(self.array, 'array', self.array)
-        result = array[key]
+        result = robust_getitem(array, key, catch=ValueError)
         # pydap doesn't squeeze axes automatically like numpy
         axis = tuple(n for n, k in enumerate(key)
                      if isinstance(k, (int, np.integer)))

--- a/xray/core/utils.py
+++ b/xray/core/utils.py
@@ -4,6 +4,8 @@ import contextlib
 import datetime
 import functools
 import itertools
+import re
+import traceback
 import warnings
 from collections import Mapping, MutableMapping
 
@@ -11,7 +13,7 @@ import numpy as np
 import pandas as pd
 
 from . import ops
-from .pycompat import iteritems, OrderedDict
+from .pycompat import iteritems, OrderedDict, PY3
 
 
 def alias_warning(old_name, new_name, stacklevel=3): # pragma: no cover
@@ -385,3 +387,7 @@ def close_on_error(f):
     except Exception:
         f.close()
         raise
+
+
+def is_remote_uri(path):
+    return bool(re.search('^https?\://', path))


### PR DESCRIPTION
Accessing data from remote datasets now has retrying logic (with exponential backoff) that should make it robust to occasional bad responses from DAP servers.
