### PR TITLE
Add display_width option

### DIFF
--- a/doc/api.rst
+++ b/doc/api.rst
@@ -16,6 +16,7 @@ Top-level functions
 
    align
    concat
+   set_options
 
 Dataset
 =======

--- a/doc/whats-new.rst
+++ b/doc/whats-new.rst
@@ -17,7 +17,7 @@ computing (data that doesn't fit into memory) with dask_. For more on dask,
 read the new documentation section :doc:`dask`.
 
 We also added new top-level function :py:func:`~xray.open_mfdataset` to make it
-easy to open a collection of files (using dask) as a single `xray.Dataset`
+easy to open a collection of files (using dask) as a single ``xray.Dataset``
 object.
 
 The combination of these features makes it possible to manipulate gigantic
@@ -104,6 +104,26 @@ Enhancements
 - Accessing data from remote datasets now has retrying logic (with exponential
   backoff) that should make it robust to occasional bad responses from DAP
   servers.
+- You can control the width of the Dataset repr with :py:class:`xray.set_options`.
+  It can be used either as a context manager, in which case the default is restored
+  outside the context:
+
+  .. ipython:: python
+
+      ds = xray.Dataset({'x': np.arange(1000)})
+      with xray.set_options(display_width=40):
+          print(ds)
+      with xray.set_options(display_width=60):
+          print(ds)
+
+  Or to set a global option:
+
+  .. ipython:: python
+
+      xray.set_options(display_width=80)
+      ds
+
+  The default value for the ``display_width`` option is 80.
 
 Deprecations
 ~~~~~~~~~~~~

--- a/xray/__init__.py
+++ b/xray/__init__.py
@@ -2,6 +2,7 @@ from .core.alignment import align, broadcast_arrays, concat, auto_combine
 from .core.variable import Variable, Coordinate
 from .core.dataset import Dataset
 from .core.dataarray import DataArray
+from .core.options import set_options
 
 from .backends.api import open_dataset, open_mfdataset
 from .conventions import decode_cf

--- a/xray/core/formatting.py
+++ b/xray/core/formatting.py
@@ -1,10 +1,10 @@
 from datetime import datetime, timedelta
 import functools
-import itertools
 
 import numpy as np
 import pandas as pd
 
+from .options import OPTIONS
 from .pycompat import (OrderedDict, iteritems, itervalues, unicode_type,
                        bytes_type, dask_array_type)
 
@@ -147,7 +147,9 @@ def format_array_flat(items_ndarray, max_width):
 
 
 def _summarize_var_or_coord(name, var, col_width, show_values=True,
-                            marker=' ', max_width=100):
+                            marker=' ', max_width=None):
+    if max_width is None:
+        max_width = OPTIONS['display_width']
     first_col = pretty_print('  %s %s ' % (marker, name), col_width)
     dims_str = '(%s) ' % ', '.join(map(str, var.dims)) if var.dims else ''
     front_str = first_col + dims_str + ('%s ' % var.dtype)

--- a/xray/core/options.py
+++ b/xray/core/options.py
@@ -1,0 +1,16 @@
+OPTIONS = {'display_width': 80}
+
+
+class set_options(object):
+    """ Set global state within controlled context
+    """
+    def __init__(self, **kwargs):
+        self.old = OPTIONS.copy()
+        OPTIONS.update(kwargs)
+
+    def __enter__(self):
+        return
+
+    def __exit__(self, type, value, traceback):
+        OPTIONS.clear()
+        OPTIONS.update(self.old)


### PR DESCRIPTION
Example usage:

	In [12]: ds = xray.Dataset({'x': np.arange(1000)})

	In [13]: with xray.set_options(display_width=40):
	   ....:     print(ds)
	   ....:
	<xray.Dataset>
	Dimensions:  (x: 1000)
	Coordinates:
	  * x        (x) int64 0 1 2 3 4 5 6 ...
	Data variables:
	    *empty*

	In [14]: with xray.set_options(display_width=60):
	   ....:     print(ds)
	   ....:
	<xray.Dataset>
	Dimensions:  (x: 1000)
	Coordinates:
	  * x        (x) int64 0 1 2 3 4 5 6 7 8 9 10 11 12 13 ...
	Data variables:
	    *empty*