### PR TITLE
ENH: Add .sel() method to Dataset and DataArray

### DIFF
--- a/doc/indexing.rst
+++ b/doc/indexing.rst
@@ -261,3 +261,35 @@ Both ``reindex_like`` and ``align`` work interchangeably between
     other = xray.DataArray(['a', 'b', 'c'], dims='other')
     # this is a no-op, because there are no shared dimension names
     ds.reindex_like(other)
+
+.. _nearest neighbor lookups:
+
+Nearest neighbor lookups
+------------------------
+
+The label based selection methods :py:meth:`~xray.Dataset.sel`,
+:py:meth:`~xray.Dataset.reindex` and :py:meth:`~xray.Dataset.reindex_like` all
+support a ``method`` keyword argument. The method parameter allows for
+enabling nearest neighbor (inexact) lookups by use of the methods ``'pad'``,
+``'backfill'`` or ``'nearest'``:
+
+.. ipython:: python
+
+      data = xray.DataArray([1, 2, 3], dims='x')
+      data.sel(x=[1.1, 1.9], method='nearest')
+      data.sel(x=0.1, method='backfill')
+      data.reindex(x=[0.5, 1, 1.5, 2, 2.5], method='pad')
+
+Using ``method='nearest'`` or a scalar argument with ``.sel()`` requires pandas
+version 0.16 or newer.
+
+.. note::
+
+    The method parameter is not yet supported if any of the arguments
+    to ``.sel()`` is a ``slice`` object:
+
+    .. ipython::
+        :verbatim:
+
+        In [1]: data.sel(x=slice(1, 3), method='nearest')
+        NotImplementedError

--- a/doc/whats-new.rst
+++ b/doc/whats-new.rst
@@ -98,6 +98,16 @@ Enhancements
 
   These methods return a new Dataset (or DataArray) with updated data or
   coordinate variables.
+- :py:meth:`~xray.Dataset.sel` now supports the ``method`` parameter, which works
+  like the paramter of the same name on :py:meth:`~xray.Dataset.reindex`. It
+  provides a simple interface for doing nearest-neighbor interpolation:
+
+  .. ipython:: python
+
+      ds.sel(x=1.1, method='nearest')
+      ds.sel(x=[1.1, 2.1], method='pad')
+
+  See :ref:`nearest neighbor lookups` for more details.
 - You can now control the underlying backend used for accessing remote
   datasets (via OPeNDAP) by specifying ``engine='netcdf4'`` or
   ``engine='pydap'``.

--- a/xray/core/dataarray.py
+++ b/xray/core/dataarray.py
@@ -537,7 +537,7 @@ class DataArray(AbstractArray, BaseDataObject):
         ds = self._dataset.isel(**indexers)
         return self._with_replaced_dataset(ds)
 
-    def sel(self, **indexers):
+    def sel(self, method=None, **indexers):
         """Return a new DataArray whose dataset is given by selecting
         index labels along the specified dimension(s).
 
@@ -546,7 +546,8 @@ class DataArray(AbstractArray, BaseDataObject):
         Dataset.sel
         DataArray.isel
         """
-        return self.isel(**indexing.remap_label_indexers(self, indexers))
+        return self.isel(**indexing.remap_label_indexers(self, indexers,
+                                                         method=method))
 
     def reindex_like(self, other, method=None, copy=True):
         """Conform this object onto the indexes of another object, filling

--- a/xray/core/dataset.py
+++ b/xray/core/dataset.py
@@ -977,7 +977,7 @@ class Dataset(Mapping, ImplementsDatasetReduce, BaseDataObject):
             variables[name] = var.isel(**var_indexers)
         return self._replace_vars_and_dims(variables)
 
-    def sel(self, **indexers):
+    def sel(self, method=None, **indexers):
         """Returns a new dataset with each array indexed by tick labels
         along the specified dimension(s).
 
@@ -996,9 +996,16 @@ class Dataset(Mapping, ImplementsDatasetReduce, BaseDataObject):
 
         Parameters
         ----------
+        method : {None, 'nearest', 'pad'/'ffill', 'backfill'/'bfill'}, optional
+            Method to use for inexact matches (requires pandas>=0.16):
+
+            * default: only exact matches
+            * pad / ffill: propgate last valid index value forward
+            * backfill / bfill: propagate next valid index value backward
+            * nearest: use nearest valid index value
         **indexers : {dim: indexer, ...}
             Keyword arguments with names matching dimensions and values given
-            by individual, slices or arrays of tick labels.
+            by scalars, slices or arrays of tick labels.
 
         Returns
         -------
@@ -1015,7 +1022,8 @@ class Dataset(Mapping, ImplementsDatasetReduce, BaseDataObject):
         DataArray.isel
         DataArray.sel
         """
-        return self.isel(**indexing.remap_label_indexers(self, indexers))
+        return self.isel(**indexing.remap_label_indexers(self, indexers,
+                                                         method=method))
 
     def reindex_like(self, other, method=None, copy=True):
         """Conform this object onto the indexes of another object, filling

--- a/xray/test/test_dataarray.py
+++ b/xray/test/test_dataarray.py
@@ -369,6 +369,18 @@ class TestDataArray(TestCase):
         self.assertDataArrayIdentical(da[1], da.sel(x=b))
         self.assertDataArrayIdentical(da[[1]], da.sel(x=slice(b, b)))
 
+    def test_sel_method(self):
+        data = DataArray(np.random.randn(3, 4),
+                         [('x', [0, 1, 2]), ('y', list('abcd'))])
+
+        expected = data.sel(y=['a', 'b'])
+        actual = data.sel(y=['ab', 'ba'], method='pad')
+        self.assertDataArrayIdentical(expected, actual)
+
+        expected = data.sel(x=[1, 2])
+        actual = data.sel(x=[0.9, 1.9], method='backfill')
+        self.assertDataArrayIdentical(expected, actual)
+
     def test_loc(self):
         self.ds['x'] = ('x', np.array(list('abcdefghij')))
         da = self.ds['foo']

--- a/xray/test/test_dataset.py
+++ b/xray/test/test_dataset.py
@@ -661,6 +661,21 @@ class TestDataset(TestCase):
         self.assertDatasetEqual(data.isel(td=slice(1, 3)),
                                 data.sel(td=slice('1 days', '2 days')))
 
+    def test_sel_method(self):
+        data = create_test_data()
+
+        if pd.__version__ >= '0.16':
+            expected = data.sel(dim1=1)
+            actual = data.sel(dim1=0.95, method='nearest')
+            self.assertDatasetIdentical(expected, actual)
+
+        expected = data.sel(dim2=[1.5])
+        actual = data.sel(dim2=[1.45], method='backfill')
+        self.assertDatasetIdentical(expected, actual)
+
+        with self.assertRaisesRegexp(NotImplementedError, 'slice objects'):
+            data.sel(dim2=slice(1, 3), method='ffill')
+
     def test_loc(self):
         data = create_test_data()
         expected = data.sel(dim3='a')

--- a/xray/test/test_indexing.py
+++ b/xray/test/test_indexing.py
@@ -1,4 +1,5 @@
 import numpy as np
+import pandas as pd
 
 from xray import Dataset, Variable, Coordinate
 from xray.core import indexing, variable
@@ -68,11 +69,11 @@ class TestIndexers(TestCase):
 
     def test_convert_label_indexer(self):
         # TODO: add tests that aren't just for edge cases
-        coord = Coordinate('x', [1, 2, 3])
+        index = pd.Index([1, 2, 3])
         with self.assertRaisesRegexp(ValueError, 'not all values found'):
-            indexing.convert_label_indexer(coord, [0])
+            indexing.convert_label_indexer(index, [0])
         with self.assertRaises(KeyError):
-            indexing.convert_label_indexer(coord, 0)
+            indexing.convert_label_indexer(index, 0)
 
     def test_remap_label_indexers(self):
         # TODO: fill in more tests!


### PR DESCRIPTION
sel() now supports the method parameter, which works like the paramter of the
same name on reindex(). It provides a simple interface for doing nearest-
neighbor interpolation:

	In [12]: ds.sel(x=1.1, method='nearest')
	Out[12]:
	<xray.Dataset>
	Dimensions:  ()
	Coordinates:
	    x        int64 1
	Data variables:
	    y        int64 2

	In [13]: ds.sel(x=[1.1, 2.1], method='pad')
	Out[13]:
	<xray.Dataset>
	Dimensions:  (x: 2)
	Coordinates:
	  * x        (x) int64 1 2
	Data variables:
	    y        (x) int64 2 3