### PR TITLE
Decode non-native endianness

### DIFF
--- a/xray/test/test_backends.py
+++ b/xray/test/test_backends.py
@@ -598,6 +598,12 @@ class ScipyOnDiskDataTest(CFEncodedDataTest, Only32BitTypes, TestCase):
                 with open_example_dataset('example_1.nc') as actual:
                     self.assertDatasetIdentical(expected, actual)
 
+    def test_netcdf3_endianness(self):
+        # regression test for GH416
+        expected = open_example_dataset('bears.nc', engine='scipy')
+        for var in expected.values():
+            self.assertTrue(var.dtype.isnative)
+
 
 @requires_netCDF4
 class NetCDF3ViaNetCDF4DataTest(CFEncodedDataTest, Only32BitTypes, TestCase):

--- a/xray/test/test_conventions.py
+++ b/xray/test/test_conventions.py
@@ -411,6 +411,16 @@ class TestDatetime(TestCase):
         self.assertIn('(time) datetime64[ns]', repr(ds))
 
 
+class TestNativeEndiannessArray(TestCase):
+    def test(self):
+        x = np.arange(5, dtype='>i8')
+        expected = np.arange(5, dtype='int64')
+        a = conventions.NativeEndiannessArray(x)
+        assert a.dtype == expected.dtype
+        assert a.dtype == expected[:].dtype
+        self.assertArrayEqual(a, expected)
+
+
 @requires_netCDF4
 class TestEncodeCFVariable(TestCase):
     def test_incompatible_attributes(self):


### PR DESCRIPTION
Fixes #416

By the way, it turns out the simple work around for this was to install netCDF4 -- only scipy.io.netcdf returns the big-endian arrays directly.

CC @bareid