### PR TITLE
Assign order

### DIFF
--- a/doc/api.rst
+++ b/doc/api.rst
@@ -66,6 +66,7 @@ Dataset contents
    Dataset.copy
    Dataset.assign
    Dataset.assign_coords
+   Dataset.pipe
    Dataset.merge
    Dataset.rename
    Dataset.swap_dims

--- a/doc/data-structures.rst
+++ b/doc/data-structures.rst
@@ -391,7 +391,9 @@ follow nested function calls:
      .mean('y')
      .pipe(plt.plot))
 
-Both ``pipe`` and ``assign`` replicate the pandas methods of the same name.
+Both ``pipe`` and ``assign`` replicate the pandas methods of the same names
+(:py:meth:`DataFrame.pipe <pandas.DataFrame.pipe>` and
+:py:meth:`DataFrame.assign <pandas.DataFrame.assign>`).
 
 With xray, there is no performance penalty for creating new datasets, even if
 variables are lazily loaded from a file on disk. Creating new objects instead

--- a/doc/whats-new.rst
+++ b/doc/whats-new.rst
@@ -15,11 +15,13 @@ v0.5.1 (unreleased)
 Enhancements
 ~~~~~~~~~~~~
 
-- Added :py:meth:`~xray.Dataset.pipe`, replicating the new pandas method in version
+- Added :py:meth:`~xray.Dataset.pipe`, replicating the `new pandas method`_ in version
   0.16.2. See :doc:`transforming datasets` for more details.
 - :py:meth:`~xray.Dataset.assign` and :py:meth:`~xray.Dataset.assign_coords`
   now assign new variables in sorted (alphabetical) order, mirroring the
   behavior in pandas. Previously, the order was arbitrary.
+
+.. _new pandas method: http://pandas.pydata.org/pandas-docs/version/0.16.2/whatsnew.html#pipe
 
 Bug fixes
 ~~~~~~~~~

--- a/doc/whats-new.rst
+++ b/doc/whats-new.rst
@@ -17,6 +17,9 @@ Enhancements
 
 - Added :py:meth:`~xray.Dataset.pipe`, replicating the new pandas method in version
   0.16.2. See :doc:`transforming datasets` for more details.
+- :py:meth:`~xray.Dataset.assign` and :py:meth:`~xray.Dataset.assign_coords`
+  now assign new variables in sorted (alphabetical) order, mirroring the
+  behavior in pandas. Previously, the order was arbitrary.
 
 Bug fixes
 ~~~~~~~~~

--- a/xray/core/common.py
+++ b/xray/core/common.py
@@ -5,6 +5,7 @@ import pandas as pd
 
 from .pycompat import basestring, iteritems
 from . import formatting
+from .utils import SortedKeysDict
 
 
 class ImplementsArrayReduce(object):
@@ -145,7 +146,7 @@ class AttrAccessMixin(object):
 
 class BaseDataObject(AttrAccessMixin):
     def _calc_assign_results(self, kwargs):
-        results = {}
+        results = SortedKeysDict()
         for k, v in kwargs.items():
             if callable(v):
                 results[k] = v(self)

--- a/xray/test/test_dataset.py
+++ b/xray/test/test_dataset.py
@@ -1176,9 +1176,10 @@ class TestDataset(TestCase):
 
     def test_assign(self):
         ds = Dataset()
-        actual = ds.assign(x = [0, 1, 2])
-        expected = Dataset({'x': [0, 1, 2]})
+        actual = ds.assign(x = [0, 1, 2], y = 2)
+        expected = Dataset({'x': [0, 1, 2], 'y': 2})
         self.assertDatasetIdentical(actual, expected)
+        self.assertEqual(list(actual), ['x', 'y'])
         self.assertDatasetIdentical(ds, Dataset())
 
         actual = actual.assign(y = lambda ds: ds.x ** 2)


### PR DESCRIPTION
`xray.Dataset.assign` and `xray.Dataset.assign_coords` now assign new
variables in sorted (alphabetical) order, mirroring the behavior in pandas.
 Previously, the order was arbitrary.
