### PR TITLE
Add xray.save_mfdataset

### DIFF
--- a/doc/api.rst
+++ b/doc/api.rst
@@ -345,6 +345,7 @@ Dataset methods
    open_dataset
    open_mfdataset
    Dataset.to_netcdf
+   save_mfdataset
    Dataset.to_array
    Dataset.to_dataframe
    Dataset.from_dataframe

--- a/doc/whats-new.rst
+++ b/doc/whats-new.rst
@@ -23,6 +23,19 @@ Enhancements
   thread lock by default for reading from netCDF files. This avoids possible
   segmentation faults for reading from netCDF4 files when HDF5 is not
   configured properly for concurrent access (:issue:`444`).
+- The new :py:func:`~xray.save_mfdataset` function allows for saving multiple
+  datasets to disk simultaneously. This is useful when processing large datasets
+  with dask.array. For example, to save a dataset too big to fit into memory
+  to one file per year, we could write:
+
+  .. ipython::
+    :verbatim:
+
+    In [1]: years, datasets = zip(*ds.groupby('time.year'))
+
+    In [2]: paths = ['%s.nc' % y for y in years]
+
+    In [3]: xray.save_mfdataset(datasets, paths)
 
 Bug fixes
 ~~~~~~~~~

--- a/xray/__init__.py
+++ b/xray/__init__.py
@@ -4,7 +4,7 @@ from .core.dataset import Dataset
 from .core.dataarray import DataArray
 from .core.options import set_options
 
-from .backends.api import open_dataset, open_mfdataset
+from .backends.api import open_dataset, open_mfdataset, save_mfdataset
 from .conventions import decode_cf
 
 from .version import version as __version__

--- a/xray/backends/common.py
+++ b/xray/backends/common.py
@@ -168,6 +168,10 @@ class ArrayWriter(object):
 
 
 class AbstractWritableDataStore(AbstractDataStore):
+    def __init__(self, writer=None):
+        if writer is None:
+            writer = ArrayWriter()
+        self.writer = writer
 
     def set_dimension(self, d, l):  # pragma: no cover
         raise NotImplementedError
@@ -179,7 +183,7 @@ class AbstractWritableDataStore(AbstractDataStore):
         raise NotImplementedError
 
     def sync(self):
-        pass
+        self.writer.sync()
 
     def store_dataset(self, dataset):
         # in stores variables are all variables AND coordinates
@@ -202,12 +206,10 @@ class AbstractWritableDataStore(AbstractDataStore):
             self.set_attribute(k, v)
 
     def set_variables(self, variables):
-        writer = ArrayWriter()
         for vn, v in iteritems(variables):
             name = _encode_variable_name(vn)
             target, source = self.prepare_variable(name, v)
-            writer.add(source, target)
-        writer.sync()
+            self.writer.add(source, target)
 
     def set_necessary_dimensions(self, variable):
         for d, l in zip(variable.dims, variable.shape):

--- a/xray/backends/h5netcdf_.py
+++ b/xray/backends/h5netcdf_.py
@@ -12,13 +12,17 @@ from .netCDF4_ import _nc4_group, _nc4_values_and_dtype
 class H5NetCDFStore(AbstractWritableDataStore):
     """Store for reading and writing data via h5netcdf
     """
-    def __init__(self, filename, mode='r', group=None):
+    def __init__(self, filename, mode='r', format=None, group=None,
+                 writer=None):
         import h5netcdf.legacyapi
+        if format not in [None, 'NETCDF4']:
+            raise ValueError('invalid format for h5netcdf backend')
         ds = h5netcdf.legacyapi.Dataset(filename, mode=mode)
         with close_on_error(ds):
             self.ds = _nc4_group(ds, group, mode)
         self.format = format
         self._filename = filename
+        super(H5NetCDFStore, self).__init__(writer)
 
     def store(self, variables, attributes):
         # All NetCDF files get CF encoded by default, without this attempting
@@ -89,6 +93,7 @@ class H5NetCDFStore(AbstractWritableDataStore):
         return nc4_var, variable.data
 
     def sync(self):
+        super(H5NetCDFStore, self).sync()
         self.ds.sync()
 
     def close(self):

--- a/xray/backends/memory.py
+++ b/xray/backends/memory.py
@@ -14,9 +14,10 @@ class InMemoryDataStore(AbstractWritableDataStore):
     in ordered dictionaries, making this store
     fast compared to stores which save to disk.
     """
-    def __init__(self, variables=None, attributes=None):
+    def __init__(self, variables=None, attributes=None, writer=None):
         self._variables = OrderedDict() if variables is None else variables
         self._attributes = OrderedDict() if attributes is None else attributes
+        super(InMemoryDataStore, self).__init__(writer)
 
     def get_attrs(self):
         return self._attributes

--- a/xray/backends/netCDF4_.py
+++ b/xray/backends/netCDF4_.py
@@ -123,9 +123,11 @@ class NetCDF4DataStore(AbstractWritableDataStore):
 
     This store supports NetCDF3, NetCDF4 and OpenDAP datasets.
     """
-    def __init__(self, filename, mode='r', clobber=True, diskless=False,
-                 persist=False, format='NETCDF4', group=None):
+    def __init__(self, filename, mode='r', format='NETCDF4', group=None,
+                 writer=None, clobber=True, diskless=False, persist=False):
         import netCDF4 as nc4
+        if format is None:
+            format = 'NETCDF4'
         ds = nc4.Dataset(filename, mode=mode, clobber=clobber,
                          diskless=diskless, persist=persist,
                          format=format)
@@ -134,6 +136,7 @@ class NetCDF4DataStore(AbstractWritableDataStore):
         self.format = format
         self.is_remote = is_remote_uri(filename)
         self._filename = filename
+        super(NetCDF4DataStore, self).__init__(writer)
 
     def store(self, variables, attributes):
         # All NetCDF files get CF encoded by default, without this attempting
@@ -232,6 +235,7 @@ class NetCDF4DataStore(AbstractWritableDataStore):
         return nc4_var, variable.data
 
     def sync(self):
+        super(NetCDF4DataStore, self).sync()
         self.ds.sync()
 
     def close(self):

--- a/xray/core/dataset.py
+++ b/xray/core/dataset.py
@@ -809,13 +809,14 @@ class Dataset(Mapping, ImplementsDatasetReduce, BaseDataObject):
                 del obj._variables[name]
         return obj
 
-    def dump_to_store(self, store, encoder=None):
+    def dump_to_store(self, store, encoder=None, sync=True):
         """Store dataset contents to a backends.*DataStore object."""
         variables, attrs = conventions.encode_dataset_coordinates(self)
         if encoder:
             variables, attrs = encoder(variables, attrs)
         store.store(variables, attrs)
-        store.sync()
+        if sync:
+            store.sync()
 
     def to_netcdf(self, path=None, mode='w', format=None, group=None,
                   engine=None):

--- a/xray/test/test_backends.py
+++ b/xray/test/test_backends.py
@@ -751,6 +751,13 @@ class DaskTest(TestCase):
                 with open_mfdataset([tmp1, tmp2]) as actual:
                     self.assertDatasetIdentical(actual, original)
 
+    def test_save_mfdataset_invalid(self):
+        ds = Dataset()
+        with self.assertRaisesRegexp(ValueError, 'cannot use mode'):
+            save_mfdataset([ds, ds], ['same', 'same'])
+        with self.assertRaisesRegexp(ValueError, 'same length'):
+            save_mfdataset([ds, ds], ['only one path'])
+
     def test_open_and_do_math(self):
         original = Dataset({'foo': ('x', np.random.randn(10))})
         with create_tmp_file() as tmp:


### PR DESCRIPTION
This function allows for saving multiple datasets to disk simultaneously, which
is useful when processing large datasets with dask.array. For example, to save
a dataset too big to fit into memory to one file per year, we could write:

	>>> years, datasets = zip(*ds.groupby('time.year'))
    >>> paths = ['%s.nc' % y for y in years]
    >>> xray.save_mfdataset(datasets, paths)