### PR TITLE
Add pointwise indexing via isel_points method

### DIFF
--- a/doc/api.rst
+++ b/doc/api.rst
@@ -93,6 +93,7 @@ Indexing
    Dataset.loc
    Dataset.isel
    Dataset.sel
+   Dataset.isel_points
    Dataset.squeeze
    Dataset.reindex
    Dataset.reindex_like
@@ -202,6 +203,7 @@ Indexing
    DataArray.loc
    DataArray.isel
    DataArray.sel
+   DataArray.isel_points
    DataArray.squeeze
    DataArray.reindex
    DataArray.reindex_like

--- a/doc/indexing.rst
+++ b/doc/indexing.rst
@@ -57,7 +57,7 @@ DataArray:
 
     Positional indexing deviates from the NumPy when indexing with multiple
     arrays like ``arr[[0, 1], [0, 1]]``, as described in :ref:`indexing details`.
-    Use :py:meth:`~xray.Dataset.isel_points` to achieve this functionality.
+    See :ref:`pointwise indexing` and :py:meth:`~xray.Dataset.isel_points` for more on this functionality.
 
 xray also supports label-based indexing, just like pandas. Because
 we use a :py:class:`pandas.Index` under the hood, label based indexing is very
@@ -135,8 +135,10 @@ __ http://legacy.python.org/dev/peps/pep-0472/
         # this is safe
         arr[dict(space=0)] = 0
 
+.. _pointwise indexing:
+
 Pointwise indexing
---------------------------------
+------------------
 
 xray pointwise indexing supports the indexing along multiple labeled dimensions
 using list-like objects. While :py:meth:`~xray.DataArray.isel` performs

--- a/doc/indexing.rst
+++ b/doc/indexing.rst
@@ -36,6 +36,8 @@ below and summarized in this table:
 | By name          | By label     | ``arr.sel(space='IA')`` or |br| | ``ds.sel(space='IA')`` or |br| |
 |                  |              | ``arr.loc[dict(space='IA')]``   | ``ds.loc[dict(space='IA')]``   |
 +------------------+--------------+---------------------------------+--------------------------------+
+| By name          | By integers  | ``arr.isel_points(x=[0, 1])``   | ``ds.isel_points(x=[0, 1])``   |
++------------------+--------------+---------------------------------+--------------------------------+
 
 Positional indexing
 -------------------
@@ -57,6 +59,7 @@ DataArray:
 
     Positional indexing deviates from the NumPy when indexing with multiple
     arrays like ``arr[[0, 1], [0, 1]]``, as described in :ref:`indexing details`.
+    Use :py:meth:`~xray.Dataset.isel_points` to achieve this functionality.
 
 xray also supports label-based indexing, just like pandas. Because
 we use a :py:class:`pandas.Index` under the hood, label based indexing is very
@@ -108,6 +111,13 @@ use them explicitly to slice data. There are two ways to do this:
         # index by dimension coordinate labels
         arr.sel(time=slice('2000-01-01', '2000-01-02'))
 
+3. Use the :py:meth:`~xray.DataArray.isel_points` method:
+
+    .. ipython:: python
+
+        # index by integer array indices
+        arr.isel_points(space=[0, 1], dim='points')
+
 The arguments to these methods can be any objects that could index the array
 along the dimension given by the keyword, e.g., labels for an individual value,
 Python :py:func:`slice` objects or 1-dimensional arrays.
@@ -122,7 +132,7 @@ __ http://legacy.python.org/dev/peps/pep-0472/
 
 .. warning::
 
-    Do not try to assign values when using ``isel`` or ``sel``::
+    Do not try to assign values when using ``isel``, ``isel_points`` or ``sel``::
 
         # DO NOT do this
         arr.isel(space=0) = 0
@@ -145,6 +155,7 @@ simultaneously, returning a new dataset:
     ds = arr.to_dataset()
     ds.isel(space=[0], time=[0])
     ds.sel(time='2000-01-01')
+    ds.isel_points(space=[0, 1], dim='points')
 
 Positional indexing on a dataset is not supported because the ordering of
 dimensions in a dataset is somewhat ambiguous (it can vary between different

--- a/doc/indexing.rst
+++ b/doc/indexing.rst
@@ -36,8 +36,6 @@ below and summarized in this table:
 | By name          | By label     | ``arr.sel(space='IA')`` or |br| | ``ds.sel(space='IA')`` or |br| |
 |                  |              | ``arr.loc[dict(space='IA')]``   | ``ds.loc[dict(space='IA')]``   |
 +------------------+--------------+---------------------------------+--------------------------------+
-| By name          | By integers  | ``arr.isel_points(x=[0, 1])``   | ``ds.isel_points(x=[0, 1])``   |
-+------------------+--------------+---------------------------------+--------------------------------+
 
 Positional indexing
 -------------------
@@ -111,13 +109,6 @@ use them explicitly to slice data. There are two ways to do this:
         # index by dimension coordinate labels
         arr.sel(time=slice('2000-01-01', '2000-01-02'))
 
-3. Use the :py:meth:`~xray.DataArray.isel_points` method:
-
-    .. ipython:: python
-
-        # index by integer array indices
-        arr.isel_points(space=[0, 1], dim='points')
-
 The arguments to these methods can be any objects that could index the array
 along the dimension given by the keyword, e.g., labels for an individual value,
 Python :py:func:`slice` objects or 1-dimensional arrays.
@@ -144,6 +135,21 @@ __ http://legacy.python.org/dev/peps/pep-0472/
         # this is safe
         arr[dict(space=0)] = 0
 
+Pointwise indexing
+--------------------------------
+
+xray pointwise indexing supports the indexing along multiple labeled dimensions
+using list-like objects. While :py:meth:`~xray.DataArray.isel` performs
+orthogonal indexing, the :py:meth:`~xray.DataArray.isel_points` method
+provides similar numpy indexing behavior as if you were using multiple lists to index an array (e.g. `arr[[0, 1], [0, 1]]` ):
+
+.. ipython:: python
+
+    # index by integer array indices
+    da = xray.DataArray(np.arange(56).reshape((7, 8)), dims=['x', 'y'])
+    da
+    da.isel_points(x=[0, 1, 6], y=[0, 1, 0])
+
 Dataset indexing
 ----------------
 
@@ -155,13 +161,15 @@ simultaneously, returning a new dataset:
     ds = arr.to_dataset()
     ds.isel(space=[0], time=[0])
     ds.sel(time='2000-01-01')
-    ds.isel_points(space=[0, 1], dim='points')
+    ds2 = da.to_dataset()
+    ds2.isel_points(x=[0, 1, 6], y=[0, 1, 0], dim='points')
 
 Positional indexing on a dataset is not supported because the ordering of
 dimensions in a dataset is somewhat ambiguous (it can vary between different
 arrays). However, you can do normal indexing with labeled dimensions:
 
 .. ipython:: python
+
 
     ds[dict(space=[0], time=[0])]
     ds.loc[dict(time='2000-01-01')]

--- a/doc/whats-new.rst
+++ b/doc/whats-new.rst
@@ -14,6 +14,7 @@ v0.5.3 (unreleased)
 
 - Dataset variables are now written to netCDF files in order of appearance
   when using the netcdf4 backend (:issue:`479`).
+- Added :py:meth:`~xray.Dataset.isel_points` and :py:meth:`~xray.DataArray.isel_points` to support pointwise indexing of Datasets and DataArrays (:issue:`475`).
 
 v0.5.2 (16 July 2015)
 ---------------------

--- a/doc/whats-new.rst
+++ b/doc/whats-new.rst
@@ -16,6 +16,35 @@ v0.5.3 (unreleased)
   when using the netcdf4 backend (:issue:`479`).
 - Added :py:meth:`~xray.Dataset.isel_points` and :py:meth:`~xray.DataArray.isel_points` to support pointwise indexing of Datasets and DataArrays (:issue:`475`).
 
+  .. ipython::
+    :verbatim:
+
+    In [1]: da = xray.DataArray(np.arange(56).reshape((7, 8)),
+                                dims=['x', 'y'])
+
+    In [2]: da
+    Out[2]:
+    <xray.DataArray (x: 7, y: 8)>
+    array([[ 0,  1,  2,  3,  4,  5,  6,  7],
+           [ 8,  9, 10, 11, 12, 13, 14, 15],
+           [16, 17, 18, 19, 20, 21, 22, 23],
+           [24, 25, 26, 27, 28, 29, 30, 31],
+           [32, 33, 34, 35, 36, 37, 38, 39],
+           [40, 41, 42, 43, 44, 45, 46, 47],
+           [48, 49, 50, 51, 52, 53, 54, 55]])
+    Coordinates:
+      * x        (x) int64 0 1 2 3 4 5 6
+      * y        (y) int64 0 1 2 3 4 5 6 7
+
+    In [3]: da.isel_points(x=[0, 1, 6], y=[0, 1, 0], dim='points')
+    Out[3]:
+    <xray.DataArray (points: 3)>
+    array([ 0,  9, 48])
+    Coordinates:
+        x        (points) int64 0 1 6
+        y        (points) int64 0 1 0
+      * points   (points) int64 0 1 2
+
 v0.5.2 (16 July 2015)
 ---------------------
 

--- a/xray/core/dataarray.py
+++ b/xray/core/dataarray.py
@@ -551,6 +551,18 @@ class DataArray(AbstractArray, BaseDataObject):
         return self.isel(**indexing.remap_label_indexers(self, indexers,
                                                          method=method))
 
+    def isel_points(self, dim='points', **indexers):
+        """Return a new DataArray whose dataset is given by pointwise integer
+        indexing along the specified dimension(s).
+
+        See Also
+        --------
+        Dataset.isel_points
+        DataArray.sel_points
+        """
+        ds = self._dataset.isel_points(dim=dim, **indexers)
+        return self._with_replaced_dataset(ds)
+
     def reindex_like(self, other, method=None, copy=True):
         """Conform this object onto the indexes of another object, filling
         in missing values with NaN.

--- a/xray/core/dataarray.py
+++ b/xray/core/dataarray.py
@@ -558,7 +558,6 @@ class DataArray(AbstractArray, BaseDataObject):
         See Also
         --------
         Dataset.isel_points
-        DataArray.sel_points
         """
         ds = self._dataset.isel_points(dim=dim, **indexers)
         return self._with_replaced_dataset(ds)

--- a/xray/core/dataset.py
+++ b/xray/core/dataset.py
@@ -1045,7 +1045,8 @@ class Dataset(Mapping, ImplementsDatasetReduce, BaseDataObject):
             existing dimension name, in which case the location of the
             dimension is unchanged. If dimension is provided as a DataArray or
             Index, its name is used as the dimension to concatenate along and
-            the values are added as a coordinate.
+            the values are added as a coordinate. Existing dimension names are
+            not valid choices.
         **indexers : {dim: indexer, ...}
             Keyword arguments with names matching dimensions and values given
             by array-like objects. All indexers must be the same length and
@@ -1091,6 +1092,11 @@ class Dataset(Mapping, ImplementsDatasetReduce, BaseDataObject):
         lengths = set(len(v) for k, v in indexers)
         if len(lengths) > 1:
             raise ValueError('All indexers must be the same length')
+
+        # Existing dimensions are not valid choices for the dim argument
+        if dim in self.dims:
+            raise ValueError('Existing dimensions are not valid choices for '
+                             'the dim argument in sel_points')
 
         # TODO: This would be sped up with vectorized indexing. This will
         # require dask to support pointwise indexing as well.

--- a/xray/core/dataset.py
+++ b/xray/core/dataset.py
@@ -1039,7 +1039,7 @@ class Dataset(Mapping, ImplementsDatasetReduce, BaseDataObject):
 
         Parameters
         ----------
-        dim : str or DataArray or pandas.Index or other list-like object, optinal
+        dim : str or DataArray or pandas.Index or other list-like object, optional
             Name of the dimension to concatenate along. If dim is provided as a
             string, it must be a new dimension name, in which case it is added
             along axis=0. If dim is provided as a DataArray or Index or

--- a/xray/test/test_dataarray.py
+++ b/xray/test/test_dataarray.py
@@ -394,7 +394,8 @@ class TestDataArray(TestCase):
         actual = da.isel_points(y=y, x=x, dim='test_coord')
         assert 'test_coord' in actual.coords
         assert actual.coords['test_coord'].shape == (len(y), )
-
+        assert all(x in actual for x in ['time', 'x', 'y', 'test_coord'])
+        assert actual.dims == ('test_coord', 'time')
         actual = da.isel_points(y=y, x=x)
         assert 'points' in actual.coords
         # Note that because xray always concatenates along the first dimension,
@@ -408,6 +409,11 @@ class TestDataArray(TestCase):
             da.isel_points(time=[1], x=[2], y=[4]).values.squeeze(),
             np_array[1, 4, 2].squeeze())
         da.isel_points(time=[1, 2])
+        y = [-1, 0]
+        x = [-2, 2]
+        expected = da.values[:, y, x]
+        actual = da.isel_points(x=x, y=y).values
+        np.testing.assert_equal(actual.T, expected)
 
         # test that the order of the indexers doesn't matter
         self.assertDataArrayIdentical(
@@ -428,6 +434,9 @@ class TestDataArray(TestCase):
         with self.assertRaisesRegexp(ValueError,
                                      'Indexers must be 1 dimensional'):
             da.isel_points(y=1, x=2)
+        with self.assertRaisesRegexp(ValueError,
+                                     'Existing dimensions are not valid'):
+            da.isel_points(y=[1, 2], x=[1, 2], dim='x')
 
     def test_loc(self):
         self.ds['x'] = ('x', np.array(list('abcdefghij')))

--- a/xray/test/test_dataarray.py
+++ b/xray/test/test_dataarray.py
@@ -435,8 +435,12 @@ class TestDataArray(TestCase):
                                      'Indexers must be 1 dimensional'):
             da.isel_points(y=1, x=2)
         with self.assertRaisesRegexp(ValueError,
-                                     'Existing dimensions are not valid'):
+                                     'Existing dimension names are not'):
             da.isel_points(y=[1, 2], x=[1, 2], dim='x')
+
+        # using non string dims
+        acutal = da.isel_points(y=[1, 2], x=[1, 2], dim=['A', 'B'])
+        assert 'points' in actual.coords
 
     def test_loc(self):
         self.ds['x'] = ('x', np.array(list('abcdefghij')))

--- a/xray/test/test_dataarray.py
+++ b/xray/test/test_dataarray.py
@@ -439,7 +439,7 @@ class TestDataArray(TestCase):
             da.isel_points(y=[1, 2], x=[1, 2], dim='x')
 
         # using non string dims
-        acutal = da.isel_points(y=[1, 2], x=[1, 2], dim=['A', 'B'])
+        actual = da.isel_points(y=[1, 2], x=[1, 2], dim=['A', 'B'])
         assert 'points' in actual.coords
 
     def test_loc(self):

--- a/xray/test/test_dataset.py
+++ b/xray/test/test_dataset.py
@@ -696,12 +696,38 @@ class TestDataset(TestCase):
                                      'Indexers must be 1 dimensional'):
             data.isel_points(dim1=1, dim2=2)
         with self.assertRaisesRegexp(ValueError,
-                                     'Existing dimensions are not valid'):
+                                     'Existing dimension names are not valid'):
             data.isel_points(dim1=[1, 2], dim2=[1, 2], dim='dim2')
+
         # test to be sure we keep around variables that were not indexed
         ds = Dataset({'x': [1, 2, 3, 4], 'y': 0})
         actual = ds.isel_points(x=[0, 1, 2])
         self.assertDataArrayIdentical(ds['y'], actual['y'])
+
+        # tests using index or DataArray as a dim
+        stations = Dataset()
+        stations['station'] = ('station', ['A', 'B', 'C'])
+        stations['dim1s'] = ('station', [1, 2, 3])
+        stations['dim2s'] = ('station', [4, 5, 1])
+
+        actual = data.isel_points(dim1=stations['dim1s'],
+                                  dim2=stations['dim2s'],
+                                  dim=stations['station'])
+        assert 'station' in actual.coords
+        assert 'station' in actual.dims
+        self.assertDataArrayIdentical(actual['station'].drop(['dim1', 'dim2']),
+                                      stations['station'])
+
+        # make sure we get the default points coordinate when a list is passed
+        actual = data.isel_points(dim1=stations['dim1s'],
+                                  dim2=stations['dim2s'],
+                                  dim=['A', 'B', 'C'])
+        assert 'points' in actual.coords
+
+        # can pass a numpy array
+        data.isel_points(dim1=stations['dim1s'],
+                         dim2=stations['dim2s'],
+                         dim=np.array([4, 5, 6]))
 
     def test_sel_method(self):
         data = create_test_data()

--- a/xray/test/test_dataset.py
+++ b/xray/test/test_dataset.py
@@ -695,6 +695,9 @@ class TestDataset(TestCase):
         with self.assertRaisesRegexp(ValueError,
                                      'Indexers must be 1 dimensional'):
             data.isel_points(dim1=1, dim2=2)
+        with self.assertRaisesRegexp(ValueError,
+                                     'Existing dimensions are not valid'):
+            data.isel_points(dim1=[1, 2], dim2=[1, 2], dim='dim2')
         # test to be sure we keep around variables that were not indexed
         ds = Dataset({'x': [1, 2, 3, 4], 'y': 0})
         actual = ds.isel_points(x=[0, 1, 2])


### PR DESCRIPTION
This provides behavior equivalent to numpy slicing with multiple lists.

Example
-------

```python
>>> da = xray.DataArray(np.arange(56).reshape((7, 8)), dims=['x', 'y'])
>>> da
<xray.DataArray (x: 7, y: 8)>
array([[ 0,  1,  2,  3,  4,  5,  6,  7],
       [ 8,  9, 10, 11, 12, 13, 14, 15],
       [16, 17, 18, 19, 20, 21, 22, 23],
       [24, 25, 26, 27, 28, 29, 30, 31],
       [32, 33, 34, 35, 36, 37, 38, 39],
       [40, 41, 42, 43, 44, 45, 46, 47],
       [48, 49, 50, 51, 52, 53, 54, 55]])
Coordinates:
  * x        (x) int64 0 1 2 3 4 5 6
  * y        (y) int64 0 1 2 3 4 5 6 7
>>> da.isel_points(x=[0, 1, 6], y=[0, 1, 0])
<xray.DataArray (points: 3)>
array([ 0,  9, 48])
Coordinates:
    y        (points) int64 0 1 0
    x        (points) int64 0 1 6
  * points   (points) int64 0 1 2
```

related: #475