### PR TITLE
Allow for multiple values in missing_value or _FillValue

### DIFF
--- a/doc/whats-new.rst
+++ b/doc/whats-new.rst
@@ -12,6 +12,9 @@ What's New
 v0.5.3 (unreleased)
 -------------------
 
+- Variables in netCDF files with multiple missing values are now decoded as NaN
+  after issuing a warning if open_dataset is called with mask_and_scale=True.
+
 - Dataset variables are now written to netCDF files in order of appearance
   when using the netcdf4 backend (:issue:`479`).
 

--- a/xray/backends/api.py
+++ b/xray/backends/api.py
@@ -85,7 +85,10 @@ def open_dataset(filename_or_obj, group=None, decode_cf=True,
         If True, replace array values equal to `_FillValue` with NA and scale
         values according to the formula `original_values * scale_factor +
         add_offset`, where `_FillValue`, `scale_factor` and `add_offset` are
-        taken from variable attributes (if they exist).
+        taken from variable attributes (if they exist).  If the `_FillValue` or
+        `missing_value` attribute contains multiple values a warning will be
+        issued and all array values matching one of the multiple values will
+        be replaced by NA.
     decode_times : bool, optional
         If True, decode times encoded in the standard NetCDF datetime format
         into datetime objects. Otherwise, leave them encoded as numbers.

--- a/xray/conventions.py
+++ b/xray/conventions.py
@@ -56,7 +56,7 @@ def mask_and_scale(array, fill_value=None, scale_factor=None, add_offset=None,
     # by default, cast to float to ensure NaN is meaningful
     values = np.array(array, dtype=dtype, copy=True)
     if fill_value is not None and not np.all(pd.isnull(fill_value)):
-        if isinstance(fill_value, np.ndarray) and len(fill_value) != 1:
+        if getattr(fill_value, 'size', 1) > 1:
             # multiple values in fill_value
             for f_value in fill_value:
                 values[values == f_value] = np.nan
@@ -727,7 +727,7 @@ def decode_cf_variable(var, concat_characters=True, mask_and_scale=True,
             attributes['_FillValue'] = attributes.pop('missing_value')
 
         fill_value = pop_to(attributes, encoding, '_FillValue')
-        if isinstance(fill_value, np.ndarray) and len(fill_value) != 1:
+        if getattr(fill_value, 'size', 1) > 1:
             warnings.warn("variable has multiple fill values {0}, decoding "
                           "all values to NaN.".format(str(fill_value)),
                           RuntimeWarning, stacklevel=3)

--- a/xray/conventions.py
+++ b/xray/conventions.py
@@ -59,7 +59,10 @@ def mask_and_scale(array, fill_value=None, scale_factor=None, add_offset=None,
         if getattr(fill_value, 'size', 1) > 1:
             # multiple values in fill_value
             for f_value in fill_value:
-                values[values == f_value] = np.nan
+                if values.ndim > 0:
+                    values[values == f_value] = np.nan
+                elif values == f_value:
+                    values = np.array(np.nan)
         else:
             if values.ndim > 0:
                 values[values == fill_value] = np.nan

--- a/xray/conventions.py
+++ b/xray/conventions.py
@@ -57,16 +57,13 @@ def mask_and_scale(array, fill_value=None, scale_factor=None, add_offset=None,
     values = np.array(array, dtype=dtype, copy=True)
     if fill_value is not None and not np.all(pd.isnull(fill_value)):
         if getattr(fill_value, 'size', 1) > 1:
-            # multiple values in fill_value
-            for f_value in fill_value:
-                if values.ndim > 0:
-                    values[values == f_value] = np.nan
-                elif values == f_value:
-                    values = np.array(np.nan)
+            fill_values = fill_value  # multiple fill values
         else:
+            fill_values = [fill_value]
+        for f_value in fill_values:
             if values.ndim > 0:
-                values[values == fill_value] = np.nan
-            elif values == fill_value:
+                values[values == f_value] = np.nan
+            elif values == f_value:
                 values = np.array(np.nan)
     if scale_factor is not None:
         values *= scale_factor

--- a/xray/conventions.py
+++ b/xray/conventions.py
@@ -58,8 +58,6 @@ def mask_and_scale(array, fill_value=None, scale_factor=None, add_offset=None,
     if fill_value is not None and not np.all(pd.isnull(fill_value)):
         if isinstance(fill_value, np.ndarray) and len(fill_value) != 1:
             # multiple values in fill_value
-            warnings.warn('fill_value contains multiple values, decoding all '
-                          'values to NaN.', RuntimeWarning, stacklevel=3)
             for f_value in fill_value:
                 values[values == f_value] = np.nan
         else:
@@ -729,6 +727,10 @@ def decode_cf_variable(var, concat_characters=True, mask_and_scale=True,
             attributes['_FillValue'] = attributes.pop('missing_value')
 
         fill_value = pop_to(attributes, encoding, '_FillValue')
+        if isinstance(fill_value, np.ndarray) and len(fill_value) != 1:
+            warnings.warn("variable has multiple fill values {0}, decoding "
+                          "all values to NaN.".format(str(fill_value)),
+                          RuntimeWarning, stacklevel=3)
         scale_factor = pop_to(attributes, encoding, 'scale_factor')
         add_offset = pop_to(attributes, encoding, 'add_offset')
         if ((fill_value is not None and not np.any(pd.isnull(fill_value)))

--- a/xray/conventions.py
+++ b/xray/conventions.py
@@ -35,7 +35,9 @@ def mask_and_scale(array, fill_value=None, scale_factor=None, add_offset=None,
         Original array of values to wrap
     fill_value : number, optional
         All values equal to fill_value in the original array are replaced
-        by NaN.
+        by NaN.  If an array of multiple values is provided a warning will be
+        issued and all array elements matching an value in the fill_value array
+        will be replaced by NaN.
     scale_factor : number, optional
         Multiply entries in the original array by this number.
     add_offset : number, optional
@@ -53,11 +55,18 @@ def mask_and_scale(array, fill_value=None, scale_factor=None, add_offset=None,
     """
     # by default, cast to float to ensure NaN is meaningful
     values = np.array(array, dtype=dtype, copy=True)
-    if fill_value is not None and not pd.isnull(fill_value):
-        if values.ndim > 0:
-            values[values == fill_value] = np.nan
-        elif values == fill_value:
-            values = np.array(np.nan)
+    if fill_value is not None and not np.all(pd.isnull(fill_value)):
+        if isinstance(fill_value, np.ndarray) and len(fill_value) != 1:
+            # multiple values in fill_value
+            warnings.warn('fill_value contains multiple values, decoding all '
+                          'values to NaN.', RuntimeWarning, stacklevel=3)
+            for f_value in fill_value:
+                values[values == f_value] = np.nan
+        else:
+            if values.ndim > 0:
+                values[values == fill_value] = np.nan
+            elif values == fill_value:
+                values = np.array(np.nan)
     if scale_factor is not None:
         values *= scale_factor
     if add_offset is not None:
@@ -722,7 +731,7 @@ def decode_cf_variable(var, concat_characters=True, mask_and_scale=True,
         fill_value = pop_to(attributes, encoding, '_FillValue')
         scale_factor = pop_to(attributes, encoding, 'scale_factor')
         add_offset = pop_to(attributes, encoding, 'add_offset')
-        if ((fill_value is not None and not pd.isnull(fill_value))
+        if ((fill_value is not None and not np.any(pd.isnull(fill_value)))
                 or scale_factor is not None or add_offset is not None):
             if isinstance(fill_value, (bytes_type, unicode_type)):
                 dtype = object

--- a/xray/test/test_conventions.py
+++ b/xray/test/test_conventions.py
@@ -41,6 +41,19 @@ class TestMaskedAndScaledArray(TestCase):
         x = conventions.MaskedAndScaledArray(np.array(0), fill_value=10)
         self.assertEqual(0, x[...])
 
+    def test_multiple_fill_value(self):
+        with warnings.catch_warnings():
+            warnings.filterwarnings('ignore',
+                                    'fill_value contains multiple')
+            x = conventions.MaskedAndScaledArray(
+                np.arange(4), fill_value=np.array([0, 1]))
+            self.assertArrayEqual([np.nan, np.nan, 2, 3], x)
+
+            x = conventions.MaskedAndScaledArray(
+                np.array(0), fill_value=np.array([0, 1]))
+            self.assertTrue(np.isnan(x))
+            self.assertTrue(np.isnan(x[...]))
+
 
 class TestCharToStringArray(TestCase):
     def test_wrapper_class(self):

--- a/xray/test/test_conventions.py
+++ b/xray/test/test_conventions.py
@@ -42,17 +42,14 @@ class TestMaskedAndScaledArray(TestCase):
         self.assertEqual(0, x[...])
 
     def test_multiple_fill_value(self):
-        with warnings.catch_warnings():
-            warnings.filterwarnings('ignore',
-                                    'fill_value contains multiple')
-            x = conventions.MaskedAndScaledArray(
-                np.arange(4), fill_value=np.array([0, 1]))
-            self.assertArrayEqual([np.nan, np.nan, 2, 3], x)
+        x = conventions.MaskedAndScaledArray(
+            np.arange(4), fill_value=np.array([0, 1]))
+        self.assertArrayEqual([np.nan, np.nan, 2, 3], x)
 
-            x = conventions.MaskedAndScaledArray(
-                np.array(0), fill_value=np.array([0, 1]))
-            self.assertTrue(np.isnan(x))
-            self.assertTrue(np.isnan(x[...]))
+        x = conventions.MaskedAndScaledArray(
+            np.array(0), fill_value=np.array([0, 1]))
+        self.assertTrue(np.isnan(x))
+        self.assertTrue(np.isnan(x[...]))
 
 
 class TestCharToStringArray(TestCase):

--- a/xray/test/test_conventions.py
+++ b/xray/test/test_conventions.py
@@ -472,6 +472,15 @@ class TestDecodeCF(TestCase):
         actual = conventions.maybe_encode_dtype(original)
         self.assertDatasetIdentical(expected, actual)
 
+    def test_decode_cf_with_multiple_missing_values(self):
+        original = Variable(['t'], [0, 1, 2],
+                            {'missing_value': np.array([0, 1])})
+        expected = Variable(['t'], [np.nan, np.nan, 2], {})
+        with warnings.catch_warnings(record=True) as w:
+            actual = conventions.decode_cf_variable(original)
+            self.assertDatasetIdentical(expected, actual)
+            self.assertIn('variable has multiple fill', str(w[0].message))
+
 
 class CFEncodedInMemoryStore(InMemoryDataStore):
     def store(self, variables, attributes):


### PR DESCRIPTION
NetCDF files which specify multiple missing_value or _FillValue values will
result in a warning being issues and any elements which match any of the
missing_value or _FillValue values being decoded as NaN.

closes #471