### PR TITLE
ENH: finite difference method `diff`

### DIFF
--- a/doc/api.rst
+++ b/doc/api.rst
@@ -110,6 +110,7 @@ Computation
    Dataset.groupby
    Dataset.resample
    Dataset.transpose
+   Dataset.diff
 
 **Aggregation**:
 :py:attr:`~Dataset.all`
@@ -223,6 +224,7 @@ Computation
    DataArray.resample
    DataArray.transpose
    DataArray.get_axis_num
+   DataArray.diff
 
 **Aggregation**:
 :py:attr:`~DataArray.all`

--- a/doc/whats-new.rst
+++ b/doc/whats-new.rst
@@ -12,6 +12,10 @@ What's New
 v0.6.0 (unreleased)
 -------------------
 
+- Added new methods :py:meth:`DataArray.diff <xray.DataArray.diff>`
+  and :py:meth:`Dataset.diff <xray.Dataset.diff>` for finite
+  difference calculations along a given axis.
+
 Bug fixes
 ~~~~~~~~~
 

--- a/xray/core/dataarray.py
+++ b/xray/core/dataarray.py
@@ -1130,6 +1130,43 @@ class DataArray(AbstractArray, BaseDataObject):
 
         return title
 
+    def diff(self, dim, n=1, label='upper'):
+        """Calculate the n-th order discrete difference along given axis.
+
+        Parameters
+        ----------
+        dim : str, optional
+            Dimension over which to calculate the finite difference.
+        n : int, optional
+            The number of times values are differenced.
+        label : str, optional
+            The new coordinate in dimension ``dim`` will have the
+            values of either the minuend's or subtrahend's coordinate
+            for values 'upper' and 'lower', respectively.  Other
+            values are not supported.
+
+        Returns
+        -------
+        difference : same type as caller
+            The n-th order finite differnce of this object.
+
+        Examples
+        --------
+        >>> arr = xray.DataArray([5, 5, 6, 6], [[1, 2, 3, 4]], ['x'])
+        >>> arr.diff('x')
+        <xray.DataArray (x: 3)>
+        array([0, 1, 0])
+        Coordinates:
+        * x        (x) int64 2 3 4
+        >>> arr.diff('x', 2)
+        <xray.DataArray (x: 2)>
+        array([ 1, -1])
+        Coordinates:
+        * x        (x) int64 3 4
+
+        """
+        ds = self._dataset.diff(n=n, dim=dim, label=label)
+        return self._with_replaced_dataset(ds)
 
 # priority most be higher than Variable to properly work with binary ufuncs
 ops.inject_all_ops_and_reduce_methods(DataArray, priority=60)

--- a/xray/test/test_dataarray.py
+++ b/xray/test/test_dataarray.py
@@ -1452,3 +1452,11 @@ class TestDataArray(TestCase):
 
         self.assertEqual(nchar, len(title))
         self.assertTrue(title.endswith('...'))
+
+    def test_dataarray_diff_n1(self):
+        da = self.ds['foo']
+        actual = da.diff('y')
+        expected = DataArray(np.diff(da.values, axis=1),
+                             [da['x'].values, da['y'].values[1:]],
+                             ['x', 'y'])
+        self.assertDataArrayEqual(expected, actual)

--- a/xray/test/test_dataset.py
+++ b/xray/test/test_dataset.py
@@ -2057,3 +2057,61 @@ class TestDataset(TestCase):
             ds.transpose('dim1', 'dim2', 'dim3')
         with self.assertRaisesRegexp(ValueError, 'arguments to transpose'):
             ds.transpose('dim1', 'dim2', 'dim3', 'time', 'extra_dim')
+
+    def test_dataset_diff_n1_simple(self):
+        ds = Dataset({'foo': ('x', [5, 5, 6, 6])})
+        actual = ds.diff('x')
+        expected = Dataset({'foo': ('x', [0, 1, 0])})
+        expected.coords['x'].values = [1, 2, 3]
+        self.assertDatasetEqual(expected, actual)
+
+    def test_dataset_diff_n1_lower(self):
+        ds = Dataset({'foo': ('x', [5, 5, 6, 6])})
+        actual = ds.diff('x', label='lower')
+        expected = Dataset({'foo': ('x', [0, 1, 0])})
+        expected.coords['x'].values = [0, 1, 2]
+        self.assertDatasetEqual(expected, actual)
+
+    def test_dataset_diff_n1(self):
+        ds = create_test_data(seed=1)
+        actual = ds.diff('dim2')
+        expected = dict()
+        expected['var1'] = DataArray(np.diff(ds['var1'].values, axis=1),
+                                     [ds['dim1'].values,
+                                      ds['dim2'].values[1:]],
+                                     ['dim1', 'dim2'])
+        expected['var2'] = DataArray(np.diff(ds['var2'].values, axis=1),
+                                     [ds['dim1'].values,
+                                      ds['dim2'].values[1:]],
+                                     ['dim1', 'dim2'])
+        expected['var3'] = ds['var3']
+        expected = Dataset(expected, coords={'time': ds['time'].values})
+        expected.coords['numbers'] = ('dim3', ds['numbers'].values)
+        self.assertDatasetEqual(expected, actual)
+
+    def test_dataset_diff_n2(self):
+        ds = create_test_data(seed=1)
+        actual = ds.diff('dim2', n=2)
+        expected = dict()
+        expected['var1'] = DataArray(np.diff(ds['var1'].values, axis=1, n=2),
+                                     [ds['dim1'].values,
+                                      ds['dim2'].values[2:]],
+                                     ['dim1', 'dim2'])
+        expected['var2'] = DataArray(np.diff(ds['var2'].values, axis=1, n=2),
+                                     [ds['dim1'].values,
+                                      ds['dim2'].values[2:]],
+                                     ['dim1', 'dim2'])
+        expected['var3'] = ds['var3']
+        expected = Dataset(expected, coords={'time': ds['time'].values})
+        expected.coords['numbers'] = ('dim3', ds['numbers'].values)
+        self.assertDatasetEqual(expected, actual)
+
+    def test_dataset_diff_exception_n_neg(self):
+        ds = create_test_data(seed=1)
+        with self.assertRaisesRegexp(ValueError, 'must be non-negative'):
+            ds.diff('dim2', n=-1)
+
+    def test_dataset_diff_exception_label_str(self):
+        ds = create_test_data(seed=1)
+        with self.assertRaisesRegexp(ValueError, '\'label\' argument has to'):
+            ds.diff('dim2', label='raise_me')


### PR DESCRIPTION
adds `diff` method to both `DataArray` and `Dataset`. closes #490 

Still to be done:

- tests

Possible enhancements:

- allow numeric `axis` instead of `dim` for `DataArray` objects. The signature would then be `DataArray.diff(dim=None, n=1, axis=None)` and I would need to check that exactly one of `dim` and `axis` is `None`. I find it a bit ugly; `DataArray.diff(n=1, dim=None, axis=None)` would be nicer in my view.  But then the signatures for `DataArray.diff` and `Dataset.diff` would be different, which is also not nice.
- allow specifying the new coordinate array explicitly via a `coord` kwarg instead of just taking the coordinate values of the upper bounds.

What do you think?