### PR TITLE
Add colormap heuristics copied from Seaborn

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -115,5 +115,5 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 
-xray includes portions of pandas and numpy. Their licenses are included in the
-licenses directory.
+xray includes portions of pandas, NumPy and Seaborn. Their licenses are
+included in the licenses directory.

--- a/licenses/SEABORN_LICENSE
+++ b/licenses/SEABORN_LICENSE
@@ -1,0 +1,27 @@
+Copyright (c) 2012-2013, Michael L. Waskom
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+* Redistributions of source code must retain the above copyright notice, this
+  list of conditions and the following disclaimer.
+
+* Redistributions in binary form must reproduce the above copyright notice,
+  this list of conditions and the following disclaimer in the documentation
+  and/or other materials provided with the distribution.
+
+* Neither the name of the {organization} nor the names of its
+  contributors may be used to endorse or promote products derived from
+  this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/xray/plotting/__init__.py
+++ b/xray/plotting/__init__.py
@@ -1,3 +1,2 @@
 from .plotting import (plot, plot_line, plot_contourf, plot_contour,
-                       plot_hist, plot_imshow, plot_pcolormesh,
-                       _infer_interval_breaks)
+                       plot_hist, plot_imshow, plot_pcolormesh)

--- a/xray/test/test_plotting.py
+++ b/xray/test/test_plotting.py
@@ -165,18 +165,18 @@ class TestPlotHistogram(PlotTestCase):
 class TestDetermineCmapParams(TestCase):
     def test_robust(self):
         data = np.random.RandomState(1).rand(100)
-        vmin, vmax, cmap = _determine_cmap_params(
-            data, vmin=None, vmax=None, cmap=None, center=None, robust=True)
+        vmin, vmax, cmap, extend = _determine_cmap_params(data, robust=True)
         self.assertEqual(vmin, np.percentile(data, 2))
         self.assertEqual(vmax, np.percentile(data, 98))
         self.assertEqual(cmap.name, 'viridis')
+        self.assertEqual(extend, 'both')
 
     def test_center(self):
         data = np.random.RandomState(2).rand(100)
-        vmin, vmax, cmap = _determine_cmap_params(
-            data, vmin=None, vmax=None, cmap=None, center=0.5, robust=False)
+        vmin, vmax, cmap, extend = _determine_cmap_params(data, center=0.5)
         self.assertEqual(vmax - 0.5, 0.5 - vmin)
         self.assertEqual(cmap, 'RdBu_r')
+        self.assertEqual(extend, 'neither')
 
 
 class Common2dMixin:
@@ -270,6 +270,19 @@ class TestContourf(Common2dMixin, PlotTestCase):
     def test_primitive_artist_returned(self):
         artist = self.plotmethod()
         self.assertTrue(isinstance(artist, mpl.contour.QuadContourSet))
+
+    def test_extend(self):
+        artist = self.plotmethod()
+        self.assertEqual(artist.extend, 'neither')
+
+        artist = self.plotmethod(robust=True)
+        self.assertEqual(artist.extend, 'both')
+
+        artist = self.plotmethod(vmin=-0, vmax=10)
+        self.assertEqual(artist.extend, 'min')
+
+        artist = self.plotmethod(vmin=-10, vmax=0)
+        self.assertEqual(artist.extend, 'max')
 
 
 class TestContour(Common2dMixin, PlotTestCase):


### PR DESCRIPTION
A diverging colormap is inferred if the values span zero.

Some examples:

Day minus night temperature:
```
(ds.t2m[3] - ds.t2m[1]).plot()
```
![image](https://cloud.githubusercontent.com/assets/1217238/8947777/0d995cd2-3554-11e5-988f-0531eb03f02f.png)

With `robust=True`:
```
(ds.t2m[3] - ds.t2m[1]).plot(robust=True)
```
![image](https://cloud.githubusercontent.com/assets/1217238/8947783/2a397610-3554-11e5-8064-5b926fd9972c.png)

With `cmap='viridis'`:
```
(ds.t2m[3] - ds.t2m[1]).plot(robust=True, cmap='viridis')
```
![image](https://cloud.githubusercontent.com/assets/1217238/8947795/51b886a4-3554-11e5-8401-d1649dbd5448.png)

cc @clarkfitzg 