### PR TITLE
ENH: where method for masking xray objects according to some criteria

### DIFF
--- a/doc/api-hidden.rst
+++ b/doc/api-hidden.rst
@@ -27,12 +27,14 @@
    Dataset.count
    Dataset.dropna
    Dataset.fillna
+   Dataset.where
 
    core.groupby.DatasetGroupBy.assign
    core.groupby.DatasetGroupBy.assign_coords
    core.groupby.DatasetGroupBy.first
    core.groupby.DatasetGroupBy.last
    core.groupby.DatasetGroupBy.fillna
+   core.groupby.DatasetGroupBy.where
 
    Dataset.argsort
    Dataset.clip
@@ -66,11 +68,13 @@
    DataArray.count
    DataArray.dropna
    DataArray.fillna
+   DataArray.where
 
    core.groupby.DataArrayGroupBy.assign_coords
    core.groupby.DataArrayGroupBy.first
    core.groupby.DataArrayGroupBy.last
    core.groupby.DataArrayGroupBy.fillna
+   core.groupby.DataArrayGroupBy.where
 
    DataArray.argsort
    DataArray.clip

--- a/doc/api.rst
+++ b/doc/api.rst
@@ -130,6 +130,7 @@ Computation
 :py:attr:`~Dataset.count`
 :py:attr:`~Dataset.dropna`
 :py:attr:`~Dataset.fillna`
+:py:attr:`~Dataset.where`
 
 **ndarray methods**:
 :py:attr:`~Dataset.argsort`
@@ -145,6 +146,7 @@ Computation
 :py:attr:`~core.groupby.DatasetGroupBy.first`
 :py:attr:`~core.groupby.DatasetGroupBy.last`
 :py:attr:`~core.groupby.DatasetGroupBy.fillna`
+:py:attr:`~core.groupby.DatasetGroupBy.where`
 
 DataArray
 =========
@@ -240,6 +242,7 @@ Computation
 :py:attr:`~DataArray.count`
 :py:attr:`~DataArray.dropna`
 :py:attr:`~DataArray.fillna`
+:py:attr:`~DataArray.where`
 
 **ndarray methods**:
 :py:attr:`~DataArray.argsort`
@@ -255,6 +258,7 @@ Computation
 :py:attr:`~core.groupby.DataArrayGroupBy.first`
 :py:attr:`~core.groupby.DataArrayGroupBy.last`
 :py:attr:`~core.groupby.DataArrayGroupBy.fillna`
+:py:attr:`~core.groupby.DataArrayGroupBy.where`
 
 Comparisons
 -----------

--- a/doc/computation.rst
+++ b/doc/computation.rst
@@ -68,13 +68,6 @@ for working with missing data from pandas:
 Like pandas, xray uses the float value ``np.nan`` (not-a-number) to represent
 missing values.
 
-To create your own mask of missing values, use :py:meth:`~xray.DataArray.where`:
-
-.. ipython:: python
-
-    x = xray.DataArray(np.arange(9).reshape(3, 3), dims=['x', 'y'])
-    x.where(x > 4)
-
 Aggregation
 ===========
 

--- a/doc/computation.rst
+++ b/doc/computation.rst
@@ -68,6 +68,13 @@ for working with missing data from pandas:
 Like pandas, xray uses the float value ``np.nan`` (not-a-number) to represent
 missing values.
 
+To create your own mask of missing values, use :py:meth:`~xray.DataArray.where`:
+
+.. ipython:: python
+
+    x = xray.DataArray(np.arange(9).reshape(3, 3), dims=['x', 'y'])
+    x.where(x > 4)
+
 Aggregation
 ===========
 

--- a/doc/indexing.rst
+++ b/doc/indexing.rst
@@ -359,3 +359,33 @@ Indexing axes with monotonic decreasing labels also works, as long as the
 
     reversed_data = data[::-1]
     reversed_data.loc[3.1:0.9]
+
+Masking with ``where``
+----------------------
+
+Indexing methods on xray objects generally return a subset of the original data.
+However, it is sometimes useful to select an object with the same shape as the
+original data, but with some elements masked. To do this type of selection in
+xray, use :py:meth:`~xray.DataArray.where`:
+
+.. ipython:: python
+
+    arr = xray.DataArray(np.arange(16).reshape(4, 4), dims=['x', 'y'])
+    arr.where(arr.x + arr.y < 4)
+
+This is particularly useful for ragged indexing of multi-dimensional data,
+e.g., to apply a 2D mask to an image. Note that ``where`` follows all the
+usual xray broadcasting and alignment rules for binary operations (e.g.,
+``+``) between the object being indexed and the condition, as described in
+:ref:`comput`:
+
+.. ipython:: python
+
+    arr.where(arr.y < 2)
+
+Multi-dimensional indexing
+--------------------------
+
+Xray does not yet support efficient routines for generalized multi-dimensional
+indexing or regridding. However, we are definitely interested in adding support
+for this in the future (see :issue:`475` for the ongoing discussion).

--- a/doc/whats-new.rst
+++ b/doc/whats-new.rst
@@ -48,6 +48,17 @@ v0.5.3 (unreleased)
         y        (points) int64 0 1 0
       * points   (points) int64 0 1 2
 
+- New :py:meth:`~xray.Dataset.where` method for masking xray objects according
+  to some criteria. This works particularly well with multi-dimensional data:
+
+  .. ipython:: python
+
+    ds = xray.Dataset(coords={'x': range(100), 'y': range(100)})
+    ds['distance'] = np.sqrt(ds.x ** 2 + ds.y ** 2)
+
+    @savefig where_example.png width=4in height=4in
+    ds.distance.where(ds.distance < 100).plot()
+
 
 Bug fixes
 ~~~~~~~~~

--- a/xray/core/common.py
+++ b/xray/core/common.py
@@ -347,6 +347,39 @@ class BaseDataObject(AttrAccessMixin):
         result = result.rename({RESAMPLE_DIM: dim.name})
         return result
 
+    def where(self, cond):
+        """Return an object of the same shape with all entries where cond is
+        True and all other entries masked.
+
+        This operation follows the normal broadcasting and alignment rules that
+        xray uses for binary arithmetic.
+
+        Parameters
+        ----------
+        cond : boolean DataArray or Dataset
+
+        Returns
+        -------
+        same type as caller
+
+        Examples
+        --------
+
+        >>> import numpy as np
+        >>> a = xray.DataArray(np.arange(25).reshape(5, 5), dims=('x', 'y'))
+        >>> a.where((a > 6) & (a < 18))
+        <xray.DataArray (x: 5, y: 5)>
+        array([[ nan,  nan,  nan,  nan,  nan],
+               [ nan,  nan,   7.,   8.,   9.],
+               [ 10.,  11.,  12.,  13.,  14.],
+               [ 15.,  16.,  17.,  nan,  nan],
+               [ nan,  nan,  nan,  nan,  nan]])
+        Coordinates:
+          * y        (y) int64 0 1 2 3 4
+          * x        (x) int64 0 1 2 3 4
+        """
+        return self._where(cond)
+
 
 def squeeze(xray_obj, dims, dim=None):
     """Squeeze the dims of an xray object."""

--- a/xray/core/groupby.py
+++ b/xray/core/groupby.py
@@ -252,6 +252,27 @@ class GroupBy(object):
         """
         return self._fillna(value)
 
+    def where(self, cond):
+        """Return an object of the same shape with all entries where cond is
+        True and all other entries masked.
+
+        This operation follows the normal broadcasting and alignment rules that
+        xray uses for binary arithmetic.
+
+        Parameters
+        ----------
+        cond : DataArray or Dataset
+
+        Returns
+        -------
+        same type as the grouped object
+
+        See also
+        --------
+        Dataset.where
+        """
+        return self._where(cond)
+
     def _first_or_last(self, op, skipna, keep_attrs):
         if isinstance(self.group_indices[0], (int, np.integer)):
             # NB. this is currently only used for reductions along an existing

--- a/xray/core/ops.py
+++ b/xray/core/ops.py
@@ -246,17 +246,24 @@ _REDUCE_DOCSTRING_TEMPLATE = \
         """
 
 
-def count(values, axis=None):
+def count(data, axis=None):
     """Count the number of non-NA in this array along the given axis or axes
     """
-    return sum(~isnull(values), axis=axis)
+    return sum(~isnull(data), axis=axis)
 
 
-def fillna(values, other):
-    """Fill missing values in this object with values from the other object.
+def fillna(data, other):
+    """Fill missing values in this object with data from the other object.
     Follows normal broadcasting and alignment rules.
     """
-    return where(isnull(values), other, values)
+    return where(isnull(data), other, data)
+
+
+def where_method(data, cond, other=np.nan):
+    """Select values from this object that are True in cond. Everything else
+    gets masked with other. Follows normal broadcasting and alignment rules.
+    """
+    return where(cond, data, other)
 
 
 @contextlib.contextmanager
@@ -406,6 +413,10 @@ def inject_binary_ops(cls, inplace=False):
     f = _func_slash_method_wrapper(fillna)
     method = cls._binary_op(f, join='left', drop_na_vars=False)
     setattr(cls, '_fillna', method)
+
+    # patch in where
+    f = _func_slash_method_wrapper(where_method, 'where')
+    setattr(cls, '_where', cls._binary_op(f))
 
     for name in NUM_BINARY_OPS:
         # only numeric operations have in-place and reflexive variants

--- a/xray/core/variable.py
+++ b/xray/core/variable.py
@@ -593,6 +593,9 @@ class Variable(common.AbstractArray, utils.NdimSizeLenMixin):
     def fillna(self, value):
         return self._fillna(value)
 
+    def where(self, cond):
+        return self._where(cond)
+
     def reduce(self, func, dim=None, axis=None, keep_attrs=False,
                allow_lazy=False, **kwargs):
         """Reduce this array by applying `func` along some dimension(s).

--- a/xray/test/test_dataset.py
+++ b/xray/test/test_dataset.py
@@ -1663,6 +1663,39 @@ class TestDataset(TestCase):
         actual = ds.groupby('b').fillna(Dataset({'a': ('b', [0, 2])}))
         self.assertDatasetIdentical(expected, actual)
 
+    def test_where(self):
+        ds = Dataset({'a': ('x', range(5))})
+        expected = Dataset({'a': ('x', [np.nan, np.nan, 2, 3, 4])})
+        actual = ds.where(ds > 1)
+        self.assertDatasetIdentical(expected, actual)
+
+        actual = ds.where(ds.a > 1)
+        self.assertDatasetIdentical(expected, actual)
+
+        actual = ds.where(ds.a.values > 1)
+        self.assertDatasetIdentical(expected, actual)
+
+        actual = ds.where(True)
+        self.assertDatasetIdentical(ds, actual)
+
+        expected = ds.copy(deep=True)
+        expected['a'].values = [np.nan] * 5
+        actual = ds.where(False)
+        self.assertDatasetIdentical(expected, actual)
+
+        # 2d
+        ds = Dataset({'a': (('x', 'y'), [[0, 1], [2, 3]])})
+        expected = Dataset({'a': (('x', 'y'), [[np.nan, 1], [2, 3]])})
+        actual = ds.where(ds > 0)
+        self.assertDatasetIdentical(expected, actual)
+
+        # groupby
+        ds = Dataset({'a': ('x', range(5))}, {'c': ('x', [0, 0, 1, 1, 1])})
+        cond = Dataset({'a': ('c', [True, False])})
+        expected = ds.copy(deep=True)
+        expected['a'].values = [0, 1] + [np.nan] * 3
+        actual = ds.groupby('c').where(cond)
+        self.assertDatasetIdentical(expected, actual)
 
     def test_reduce(self):
         data = create_test_data()


### PR DESCRIPTION
Fixes #503

Example usage:

	In [13]: x = xray.DataArray(np.arange(9).reshape(3, 3), dims=['x', 'y'])

	In [14]: x.where(x > 4)
	Out[14]:
	<xray.DataArray (x: 3, y: 3)>
	array([[ nan,  nan,  nan],
	       [ nan,  nan,   5.],
	       [  6.,   7.,   8.]])
	Coordinates:
	  * y        (y) int64 0 1 2
	  * x        (x) int64 0 1 2

Example from "What's new":

```
In [4]: ds = xray.Dataset(coords={'x': range(100), 'y': range(100)})

In [5]: ds['distance'] = np.sqrt(ds.x ** 2 + ds.y ** 2)

In [6]: ds.distance.where(ds.distance < 100).plot()
Out[6]: <matplotlib.image.AxesImage at 0x11a819690>
```
![image](https://cloud.githubusercontent.com/assets/1217238/8996204/156e7dfc-36cb-11e5-8097-fdd1de462a2d.png)
