### PR TITLE
Add sel_points for point-wise indexing by label

### DIFF
--- a/doc/api.rst
+++ b/doc/api.rst
@@ -94,6 +94,7 @@ Indexing
    Dataset.isel
    Dataset.sel
    Dataset.isel_points
+   Dataset.sel_points
    Dataset.squeeze
    Dataset.reindex
    Dataset.reindex_like
@@ -206,6 +207,7 @@ Indexing
    DataArray.isel
    DataArray.sel
    DataArray.isel_points
+   DataArray.sel_points
    DataArray.squeeze
    DataArray.reindex
    DataArray.reindex_like

--- a/doc/indexing.rst
+++ b/doc/indexing.rst
@@ -162,6 +162,9 @@ allows you to do point-wise indexing by label:
     times = pd.to_datetime(['2000-01-03', '2000-01-02', '2000-01-01'])
     arr.sel_points(space=['IA', 'IL', 'IN'], time=times)
 
+The equivalent pandas method to ``sel_points`` is
+:py:meth:`~pandas.DataFrame.lookup`.
+
 Dataset indexing
 ----------------
 

--- a/doc/indexing.rst
+++ b/doc/indexing.rst
@@ -57,7 +57,7 @@ DataArray:
 
     Positional indexing deviates from the NumPy when indexing with multiple
     arrays like ``arr[[0, 1], [0, 1]]``, as described in :ref:`indexing details`.
-    See :ref:`pointwise indexing` and :py:meth:`~xray.Dataset.isel_points` for more on this functionality.
+    See :ref:`pointwise indexing` for how to achieve this functionality in xray.
 
 xray also supports label-based indexing, just like pandas. Because
 we use a :py:class:`pandas.Index` under the hood, label based indexing is very
@@ -123,7 +123,8 @@ __ http://legacy.python.org/dev/peps/pep-0472/
 
 .. warning::
 
-    Do not try to assign values when using ``isel``, ``isel_points`` or ``sel``::
+    Do not try to assign values when using any of the indexing methods ``isel``,
+    ``isel_points``, ``sel`` or ``sel_points``::
 
         # DO NOT do this
         arr.isel(space=0) = 0
@@ -143,7 +144,8 @@ Pointwise indexing
 xray pointwise indexing supports the indexing along multiple labeled dimensions
 using list-like objects. While :py:meth:`~xray.DataArray.isel` performs
 orthogonal indexing, the :py:meth:`~xray.DataArray.isel_points` method
-provides similar numpy indexing behavior as if you were using multiple lists to index an array (e.g. `arr[[0, 1], [0, 1]]` ):
+provides similar numpy indexing behavior as if you were using multiple
+lists to index an array (e.g. ``arr[[0, 1], [0, 1]]`` ):
 
 .. ipython:: python
 
@@ -151,6 +153,14 @@ provides similar numpy indexing behavior as if you were using multiple lists to 
     da = xray.DataArray(np.arange(56).reshape((7, 8)), dims=['x', 'y'])
     da
     da.isel_points(x=[0, 1, 6], y=[0, 1, 0])
+
+There is also :py:meth:`~xray.DataArray.sel_points`, which analogously
+allows you to do point-wise indexing by label:
+
+.. ipython:: python
+
+    times = pd.to_datetime(['2000-01-03', '2000-01-02', '2000-01-01'])
+    arr.sel_points(space=['IA', 'IL', 'IN'], time=times)
 
 Dataset indexing
 ----------------

--- a/doc/whats-new.rst
+++ b/doc/whats-new.rst
@@ -17,13 +17,16 @@ v0.5.3 (unreleased)
 
 - Dataset variables are now written to netCDF files in order of appearance
   when using the netcdf4 backend (:issue:`479`).
-- Added :py:meth:`~xray.Dataset.isel_points` and :py:meth:`~xray.DataArray.isel_points` to support pointwise indexing of Datasets and DataArrays (:issue:`475`).
+- Added :py:meth:`~xray.Dataset.isel_points` and :py:meth:`~xray.Dataset.sel_points`
+  to support pointwise indexing of Datasets and DataArrays (:issue:`475`).
 
   .. ipython::
     :verbatim:
 
     In [1]: da = xray.DataArray(np.arange(56).reshape((7, 8)),
-                                dims=['x', 'y'])
+       ...:                     coords={'x': list('abcdefg'),
+       ...:                             'y': 10 * np.arange(8)},
+       ...:                     dims=['x', 'y'])
 
     In [2]: da
     Out[2]:
@@ -36,16 +39,27 @@ v0.5.3 (unreleased)
            [40, 41, 42, 43, 44, 45, 46, 47],
            [48, 49, 50, 51, 52, 53, 54, 55]])
     Coordinates:
-      * x        (x) int64 0 1 2 3 4 5 6
-      * y        (y) int64 0 1 2 3 4 5 6 7
+    * y        (y) int64 0 10 20 30 40 50 60 70
+    * x        (x) |S1 'a' 'b' 'c' 'd' 'e' 'f' 'g'
 
+    # we can index by position along each dimension
     In [3]: da.isel_points(x=[0, 1, 6], y=[0, 1, 0], dim='points')
     Out[3]:
     <xray.DataArray (points: 3)>
     array([ 0,  9, 48])
     Coordinates:
-        x        (points) int64 0 1 6
-        y        (points) int64 0 1 0
+        y        (points) int64 0 10 0
+        x        (points) |S1 'a' 'b' 'g'
+      * points   (points) int64 0 1 2
+
+    # or equivalently by label
+    In [9]: da.sel_points(x=['a', 'b', 'g'], y=[0, 10, 0], dim='points')
+    Out[9]:
+    <xray.DataArray (points: 3)>
+    array([ 0,  9, 48])
+    Coordinates:
+        y        (points) int64 0 10 0
+        x        (points) |S1 'a' 'b' 'g'
       * points   (points) int64 0 1 2
 
 - New :py:meth:`~xray.Dataset.where` method for masking xray objects according
@@ -58,7 +72,6 @@ v0.5.3 (unreleased)
 
     @savefig where_example.png width=4in height=4in
     ds.distance.where(ds.distance < 100).plot()
-
 
 Bug fixes
 ~~~~~~~~~

--- a/xray/core/alignment.py
+++ b/xray/core/alignment.py
@@ -119,7 +119,7 @@ def reindex_variables(variables, indexes, indexers, method=None, copy=True):
     method : {None, 'nearest', 'pad'/'ffill', 'backfill'/'bfill'}, optional
         Method to use for filling index values in ``indexers`` not found in
         this dataset:
-          * default: don't fill gaps
+          * None (default): don't fill gaps
           * pad / ffill: propgate last valid index value forward
           * backfill / bfill: propagate next valid index value backward
           * nearest: use nearest valid index value

--- a/xray/core/dataarray.py
+++ b/xray/core/dataarray.py
@@ -562,6 +562,17 @@ class DataArray(AbstractArray, BaseDataObject):
         ds = self._dataset.isel_points(dim=dim, **indexers)
         return self._with_replaced_dataset(ds)
 
+    def sel_points(self, dim='points', method=None, **indexers):
+        """Return a new DataArray whose dataset is given by pointwise selection
+        of index labels along the specified dimension(s).
+
+        See Also
+        --------
+        Dataset.sel_points
+        """
+        ds = self._dataset.sel_points(dim=dim, method=method, **indexers)
+        return self._with_replaced_dataset(ds)
+
     def reindex_like(self, other, method=None, copy=True):
         """Conform this object onto the indexes of another object, filling
         in missing values with NaN.

--- a/xray/core/dataarray.py
+++ b/xray/core/dataarray.py
@@ -590,7 +590,7 @@ class DataArray(AbstractArray, BaseDataObject):
             Method to use for filling index values from other not found on this
             data array:
 
-            * default: don't fill gaps
+            * None (default): don't fill gaps
             * pad / ffill: propgate last valid index value forward
             * backfill / bfill: propagate next valid index value backward
             * nearest: use nearest valid index value (requires pandas>=0.16)
@@ -626,7 +626,7 @@ class DataArray(AbstractArray, BaseDataObject):
             Method to use for filling index values in ``indexers`` not found on
             this data array:
 
-            * default: don't fill gaps
+            * None (default): don't fill gaps
             * pad / ffill: propgate last valid index value forward
             * backfill / bfill: propagate next valid index value backward
             * nearest: use nearest valid index value (requires pandas>=0.16)

--- a/xray/core/dataset.py
+++ b/xray/core/dataset.py
@@ -1004,7 +1004,7 @@ class Dataset(Mapping, ImplementsDatasetReduce, BaseDataObject):
         method : {None, 'nearest', 'pad'/'ffill', 'backfill'/'bfill'}, optional
             Method to use for inexact matches (requires pandas>=0.16):
 
-            * default: only exact matches
+            * None (default): only exact matches
             * pad / ffill: propgate last valid index value forward
             * backfill / bfill: propagate next valid index value backward
             * nearest: use nearest valid index value
@@ -1140,7 +1140,7 @@ class Dataset(Mapping, ImplementsDatasetReduce, BaseDataObject):
         method : {None, 'nearest', 'pad'/'ffill', 'backfill'/'bfill'}, optional
             Method to use for inexact matches (requires pandas>=0.16):
 
-            * default: only exact matches
+            * None (default): only exact matches
             * pad / ffill: propgate last valid index value forward
             * backfill / bfill: propagate next valid index value backward
             * nearest: use nearest valid index value
@@ -1185,7 +1185,7 @@ class Dataset(Mapping, ImplementsDatasetReduce, BaseDataObject):
             Method to use for filling index values from other not found in this
             dataset:
 
-            * default: don't fill gaps
+            * None (default): don't fill gaps
             * pad / ffill: propgate last valid index value forward
             * backfill / bfill: propagate next valid index value backward
             * nearest: use nearest valid index value (requires pandas>=0.16)
@@ -1222,7 +1222,7 @@ class Dataset(Mapping, ImplementsDatasetReduce, BaseDataObject):
             Method to use for filling index values in ``indexers`` not found in
             this dataset:
 
-            * default: don't fill gaps
+            * None (default): don't fill gaps
             * pad / ffill: propgate last valid index value forward
             * backfill / bfill: propagate next valid index value backward
             * nearest: use nearest valid index value (requires pandas>=0.16)

--- a/xray/test/test_dataarray.py
+++ b/xray/test/test_dataarray.py
@@ -382,7 +382,7 @@ class TestDataArray(TestCase):
         actual = data.sel(x=[0.9, 1.9], method='backfill')
         self.assertDataArrayIdentical(expected, actual)
 
-    def test_isel_points_method(self):
+    def test_isel_points(self):
         shape = (10, 5, 6)
         np_array = np.random.random(shape)
         da = DataArray(np_array, dims=['time', 'y', 'x'])
@@ -441,6 +441,16 @@ class TestDataArray(TestCase):
         # using non string dims
         actual = da.isel_points(y=[1, 2], x=[1, 2], dim=['A', 'B'])
         assert 'points' in actual.coords
+
+    def test_isel_points(self):
+        shape = (10, 5, 6)
+        np_array = np.random.random(shape)
+        da = DataArray(np_array, dims=['time', 'y', 'x'])
+        y = [1, 3]
+        x = [3, 0]
+        expected = da.isel_points(x=x, y=y)
+        actual = da.sel_points(x=x, y=y)
+        self.assertDataArrayIdentical(expected, actual)
 
     def test_loc(self):
         self.ds['x'] = ('x', np.array(list('abcdefghij')))

--- a/xray/test/test_dataset.py
+++ b/xray/test/test_dataset.py
@@ -729,6 +729,26 @@ class TestDataset(TestCase):
                          dim2=stations['dim2s'],
                          dim=np.array([4, 5, 6]))
 
+    def test_sel_points(self):
+        data = create_test_data()
+
+        pdim1 = [1, 2, 3]
+        pdim2 = [4, 5, 1]
+        pdim3 = [1, 2, 3]
+        expected = data.isel_points(dim1=pdim1, dim2=pdim2, dim3=pdim3,
+                                    dim='test_coord')
+        actual = data.sel_points(dim1=data.dim1[pdim1], dim2=data.dim2[pdim2],
+                                 dim3=data.dim3[pdim3], dim='test_coord')
+        self.assertDatasetIdentical(expected, actual)
+
+        data = Dataset({'foo': (('x', 'y'), np.arange(9).reshape(3, 3))})
+        expected = Dataset({'foo': ('points', [0, 4, 8])},
+                           {'x': ('points', range(3)),
+                            'y': ('points', range(3))})
+        actual = data.sel_points(x=[0.1, 1.1, 2.5], y=[0, 1.2, 2.0],
+                                 method='pad')
+        self.assertDatasetIdentical(expected, actual)
+
     def test_sel_method(self):
         data = create_test_data()
 


### PR DESCRIPTION
xref #475

Example usage:

	In [1]: da = xray.DataArray(np.arange(56).reshape((7, 8)),
	   ...:                     coords={'x': list('abcdefg'),
	   ...:                             'y': 10 * np.arange(8)},
	   ...:                     dims=['x', 'y'])
	   ...:

	In [2]: da
	Out[2]:
	<xray.DataArray (x: 7, y: 8)>
	array([[ 0,  1,  2,  3,  4,  5,  6,  7],
	       [ 8,  9, 10, 11, 12, 13, 14, 15],
	       [16, 17, 18, 19, 20, 21, 22, 23],
	       [24, 25, 26, 27, 28, 29, 30, 31],
	       [32, 33, 34, 35, 36, 37, 38, 39],
	       [40, 41, 42, 43, 44, 45, 46, 47],
	       [48, 49, 50, 51, 52, 53, 54, 55]])
	Coordinates:
	* y        (y) int64 0 10 20 30 40 50 60 70
	* x        (x) |S1 'a' 'b' 'c' 'd' 'e' 'f' 'g'

	# we can index by position along each dimension
	In [3]: da.isel_points(x=[0, 1, 6], y=[0, 1, 0], dim='points')
	Out[3]:
	<xray.DataArray (points: 3)>
	array([ 0,  9, 48])
	Coordinates:
	    y        (points) int64 0 10 0
	    x        (points) |S1 'a' 'b' 'g'
	  * points   (points) int64 0 1 2

	# or equivalently by label
	In [4]: da.sel_points(x=['a', 'b', 'g'], y=[0, 10, 0], dim='points')
	Out[4]:
	<xray.DataArray (points: 3)>
	array([ 0,  9, 48])
	Coordinates:
	    y        (points) int64 0 10 0
	    x        (points) |S1 'a' 'b' 'g'
	  * points   (points) int64 0 1 2
	Bug fixes

cc @jhamman