### PR TITLE
Discrete colormap/colorbar option

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,7 @@ matrix:
     env: UPDATE_ENV="conda install unittest2 pandas==0.15.0 h5py cython && pip install h5netcdf"
   # Test on Python 2.7 with and without netCDF4/scipy/cdat-lite
   - python: 2.7
-    env: UPDATE_ENV="conda install -c scitools cdat-lite h5py cython matplotlib && pip install cyordereddict h5netcdf"
+    env: UPDATE_ENV="conda install -c scitools cdat-lite h5py cython matplotlib seaborn && pip install cyordereddict h5netcdf"
   - python: 2.7
     # nb. we have to remove scipy because conda install pandas brings it in:
     # https://github.com/ContinuumIO/anaconda-issues/issues/145
@@ -19,7 +19,7 @@ matrix:
   - python: 3.3
     env: UPDATE_ENV="conda remove netCDF4"
   - python: 3.4
-    env: UPDATE_ENV="conda install -c pandas bottleneck h5py cython dask matplotlib && pip install cyordereddict h5netcdf"
+    env: UPDATE_ENV="conda install -c pandas bottleneck h5py cython dask matplotlib seaborn && pip install cyordereddict h5netcdf"
   # don't require pydap tests to pass because the dap test server is unreliable
   - python: 2.7
     env: UPDATE_ENV="pip install pydap"

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,7 @@ matrix:
     env: UPDATE_ENV="conda install unittest2 pandas==0.15.0 h5py cython && pip install h5netcdf"
   # Test on Python 2.7 with and without netCDF4/scipy/cdat-lite
   - python: 2.7
-    env: UPDATE_ENV="conda install -c scitools cdat-lite h5py cython matplotlib seaborn && pip install cyordereddict h5netcdf"
+    env: UPDATE_ENV="conda install -c scitools cdat-lite h5py cython matplotlib && pip install cyordereddict h5netcdf"
   - python: 2.7
     # nb. we have to remove scipy because conda install pandas brings it in:
     # https://github.com/ContinuumIO/anaconda-issues/issues/145

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -42,6 +42,11 @@ try:
     print "ipython: %s, %s" % (IPython.__version__, IPython.__file__)
 except ImportError:
     print "no ipython"
+try:
+    import seaborn
+    print "seaborn: %s, %s" % (seaborn.__version__, seaborn.__file__)
+except ImportError:
+    print "no seaborn"
 
 # If extensions (or modules to document with autodoc) are in another directory,
 # add these directories to sys.path here. If the directory is relative to the

--- a/doc/plotting.rst
+++ b/doc/plotting.rst
@@ -201,7 +201,7 @@ distance from a 2d grid point to the origin.
 
     distance = np.linalg.norm(xy, axis=2)
 
-    distance = xray.DataArray(distance, zip(('y', 'x'), (y, x))))
+    distance = xray.DataArray(distance, zip(('y', 'x'), (y, x)))
     distance
 
 Note the coordinate ``y`` here is decreasing.

--- a/doc/plotting.rst
+++ b/doc/plotting.rst
@@ -201,7 +201,7 @@ distance from a 2d grid point to the origin.
 
     distance = np.linalg.norm(xy, axis=2)
 
-    distance = xray.DataArray(distance, zip(('y', 'x'), (y, x)))
+    distance = xray.DataArray(distance, zip(('y', 'x'), (y, x))))
     distance
 
 Note the coordinate ``y`` here is decreasing.
@@ -328,6 +328,35 @@ Take a closer look:
 In general xray's plotting functions modify the axes and
 return the same objects that the wrapped
 matplotlib functions return.
+
+Discrete Colormaps
+~~~~~~~~~~~~~~~~~~
+
+It is often useful, when visualizing 2d data, to use a discrete colormap,
+rather than the default continuous colormaps that matplotlib uses. The
+``levels`` keyword argument can be used to generate plots with discrete
+colormaps. For example, to make a plot with 8 discrete color intervals:
+
+.. ipython:: python
+
+    @savefig plotting_discrete_levels.png width=4in
+    distance.plot(levels=8)
+
+It is also possible to use a list of levels to specify the boundaries of the
+discrete colormap:
+
+.. ipython:: python
+
+    @savefig plotting_listed_levels.png width=4in
+    distance.plot(levels=[2, 5, 10, 11])
+
+Finally, if you are have `Seaborn <http://stanford.edu/~mwaskom/software/seaborn/>`_ installed, you can also specify a `seaborn` color palete or a list of colors as the ``cmap`` argument:
+
+.. ipython:: python
+
+    flatui = ["#9b59b6", "#3498db", "#95a5a6", "#e74c3c", "#34495e", "#2ecc71"]
+    @savefig plotting_custom_colors_levels.png width=4in
+    distance.plot(levels=[1, 2, 4, 5, 7], cmap=flatui)
 
 Maps
 ----

--- a/doc/requirements.txt
+++ b/doc/requirements.txt
@@ -4,7 +4,7 @@ sphinx==1.2.3
 # available in RTD's system site-packages
 ipython==3.1.0
 pandas==0.16.1
-seaborn==0.5.1
+seaborn==0.6.0
 python-dateutil
 numpydoc==0.5
 dask==0.5

--- a/xray/plot/plot.py
+++ b/xray/plot/plot.py
@@ -272,7 +272,7 @@ def _determine_cmap_params(plot_data, vmin=None, vmax=None, cmap=None,
 
 def _determine_discrete_cmap_params(cmap, levels, vmin, vmax, extend):
     """
-    Build a descrete colormap and normalization of the data.
+    Build a discrete colormap and normalization of the data.
     """
     import matplotlib as mpl
     import matplotlib.pyplot as plt
@@ -285,7 +285,9 @@ def _determine_discrete_cmap_params(cmap, levels, vmin, vmax, extend):
         ext_n = 0
 
     if isinstance(levels, int):
-        cticks = np.linspace(vmin, vmax, num=levels + 1, endpoint=True)
+        vmax += 10 * np.finfo(float).eps  # Add small epison to include vmax
+        cticks = np.linspace(vmin, vmax, num=levels + 1, endpoint=True,
+                             dtype=float)
         n_colors = levels + ext_n
     elif isinstance(levels, Sequence):
         cticks = np.asarray(levels)
@@ -373,7 +375,7 @@ def _plot2d(plotfunc):
         How to draw arrows extending the colorbar beyond its limits. If not
         provided, extend is inferred from vmin, vmax and the data limits.
     levels : int or list-like object, optional
-        Split the colormap (cmap) into descrete color intervals.
+        Split the colormap (cmap) into discrete color intervals.
     **kwargs : optional
         Additional arguments to wrapped matplotlib function
 
@@ -396,6 +398,7 @@ def _plot2d(plotfunc):
         # Method signature below should be consistent.
 
         import matplotlib.pyplot as plt
+        import matplotlib as mpl
 
         if ax is None:
             ax = plt.gca()
@@ -424,11 +427,11 @@ def _plot2d(plotfunc):
             kwargs['extend'] = extend
             kwargs['levels'] = levels
 
-        elif cnorm is not None:
-            kwargs['norm'] = cnorm
+        if cnorm is None:
+            cnorm = mpl.colors.Normalize(vmin=vmin, vmax=vmax)
 
-        ax, primitive = plotfunc(x, y, z, ax=ax, cmap=cmap, vmin=vmin,
-                                 vmax=vmax, **kwargs)
+        ax, primitive = plotfunc(x, y, z, ax=ax, cmap=cmap, norm=cnorm,
+                                 **kwargs)
 
         ax.set_xlabel(xlab)
         ax.set_ylabel(ylab)

--- a/xray/plot/plot.py
+++ b/xray/plot/plot.py
@@ -304,20 +304,17 @@ def _build_discrete_cmap(cmap, levels, extend, filled):
     """
     import matplotlib as mpl
 
-    def extension_colors(extend):
-        if extend == 'both':
-            ext_n = 2
-        elif extend in ['min', 'max']:
-            ext_n = 1
-        else:
-            ext_n = 0
-        return ext_n
-
     if not filled:
         # non-filled contour plots
         extend = 'neither'
 
-    ext_n = extension_colors(extend)
+    if extend == 'both':
+        ext_n = 2
+    elif extend in ['min', 'max']:
+        ext_n = 1
+    else:
+        ext_n = 0
+
     n_colors = len(levels) + ext_n - 1
     pal = _color_palette(cmap, n_colors)
 
@@ -469,12 +466,13 @@ def _plot2d(plotfunc):
     @functools.wraps(newplotfunc)
     def plotmethod(_PlotMethods_obj, ax=None, xincrease=None, yincrease=None,
                    add_colorbar=True, vmin=None, vmax=None, cmap=None,
-                   center=None, robust=False, extend=None, **kwargs):
+                   center=None, robust=False, extend=None, levels=None,
+                   **kwargs):
         return newplotfunc(_PlotMethods_obj._da, ax=ax, xincrease=xincrease,
                            yincrease=yincrease, add_colorbar=add_colorbar,
                            vmin=vmin, vmax=vmax, cmap=cmap,
                            center=center, robust=robust, extend=extend,
-                           **kwargs)
+                           levels=levels, **kwargs)
 
     # Add to class _PlotMethods
     setattr(_PlotMethods, plotmethod.__name__, plotmethod)

--- a/xray/plot/plot.py
+++ b/xray/plot/plot.py
@@ -263,7 +263,8 @@ def _determine_cmap_params(plot_data, vmin=None, vmax=None, cmap=None,
     if levels is not None:
         cmap, cnorm = _build_discrete_cmap(cmap, levels, extend, filled)
 
-    return vmin, vmax, cmap, extend, levels, cnorm
+    return dict(vmin=vmin, vmax=vmax, cmap=cmap, extend=extend,
+                levels=levels, cnorm=cnorm)
 
 
 def _determine_extend(calc_data, vmin, vmax):
@@ -436,27 +437,30 @@ def _plot2d(plotfunc):
             levels = 7  # this is the matplotlib default
         filled = plotfunc.__name__ != 'contour'
 
-        vmin, vmax, cmap, extend, levels, cnorm = _determine_cmap_params(
-            z.data, vmin, vmax, cmap, center, robust, extend, levels, filled)
+        cmap_params = _determine_cmap_params(z.data, vmin, vmax, cmap, center,
+                                             robust, extend, levels, filled)
 
         if 'contour' in plotfunc.__name__:
             # extend is a keyword argument only for contour and contourf, but
             # passing it to the colorbar is sufficient for imshow and
             # pcolormesh
-            kwargs['extend'] = extend
-            kwargs['levels'] = levels
+            kwargs['extend'] = cmap_params['extend']
+            kwargs['levels'] = cmap_params['levels']
 
         # This allows the user to pass in a custom norm coming via kwargs
-        kwargs.setdefault('norm', cnorm)
+        kwargs.setdefault('norm', cmap_params['cnorm'])
 
-        ax, primitive = plotfunc(x, y, z, ax=ax, cmap=cmap, vmin=vmin,
-                                 vmax=vmax, **kwargs)
+        ax, primitive = plotfunc(x, y, z, ax=ax,
+                                 cmap=cmap_params['cmap'],
+                                 vmin=cmap_params['vmin'],
+                                 vmax=cmap_params['vmax'],
+                                 **kwargs)
 
         ax.set_xlabel(xlab)
         ax.set_ylabel(ylab)
 
         if add_colorbar:
-            plt.colorbar(primitive, ax=ax, extend=extend)
+            plt.colorbar(primitive, ax=ax, extend=cmap_params['extend'])
 
         _update_axes_limits(ax, xincrease, yincrease)
 

--- a/xray/plot/plot.py
+++ b/xray/plot/plot.py
@@ -285,9 +285,10 @@ def _color_palette(cmap, n_colors):
     try:
         from seaborn.apionly import color_palette
         pal = color_palette(cmap, n_colors=n_colors)
-    except (TypeError, ImportError):
+    except (TypeError, ImportError, ValueError):
         # TypeError is raised when LinearSegmentedColormap (viridis) is used
-        # Import Error is raised when seaborn is not installed
+        # ImportError is raised when seaborn is not installed
+        # ValueError is raised when seaborn doesn't like a colormap (e.g. jet)
         # Use homegrown solution if you don't have seaborn or are using viridis
         if isinstance(cmap, basestring):
             cmap = plt.get_cmap(cmap)

--- a/xray/plot/plot.py
+++ b/xray/plot/plot.py
@@ -382,6 +382,8 @@ def _plot2d(plotfunc):
         The mapping from data values to color space. If not provided, this
         will be either be ``viridis`` (if the function infers a sequential
         dataset) or ``RdBu_r`` (if the function infers a diverging dataset).
+        When ``levels`` is provided and when `Seaborn` is installed, ``cmap``
+        may also be a `seaborn` color palette or a list of colors.
     center : float, optional
         The value at which to center the colormap. Passing this value implies
         use of a diverging colormap.

--- a/xray/test/test_plot.py
+++ b/xray/test/test_plot.py
@@ -222,6 +222,15 @@ class TestDetermineDiscreteCmapParams(TestCase):
         self.assertEqual(cnorm.vmin, min(levels))
         self.assertEqual(cnorm.vmax, max(levels))
 
+        # levels as an array
+        cmap, cnorm = _determine_discrete_cmap_params('Greens_r',
+                                                      np.array(levels),
+                                                      vmin, vmax, 'both')
+        # levels as a DataArray
+        cmap, cnorm = _determine_discrete_cmap_params('Greens_r',
+                                                      DataArray(levels),
+                                                      vmin, vmax, 'both')
+
 
 class Common2dMixin:
     """

--- a/xray/test/test_plot.py
+++ b/xray/test/test_plot.py
@@ -167,57 +167,55 @@ class TestPlotHistogram(PlotTestCase):
 class TestDetermineCmapParams(TestCase):
     def test_robust(self):
         data = np.random.RandomState(1).rand(100)
-        vmin, vmax, cmap, extend, levels, cnorm = _determine_cmap_params(
-            data, robust=True)
-        self.assertEqual(vmin, np.percentile(data, 2))
-        self.assertEqual(vmax, np.percentile(data, 98))
-        self.assertEqual(cmap.name, 'viridis')
-        self.assertEqual(extend, 'both')
-        self.assertIsNone(levels)
-        self.assertIsNone(cnorm)
+        cmap_params = _determine_cmap_params(data, robust=True)
+        self.assertEqual(cmap_params['vmin'], np.percentile(data, 2))
+        self.assertEqual(cmap_params['vmax'], np.percentile(data, 98))
+        self.assertEqual(cmap_params['cmap'].name, 'viridis')
+        self.assertEqual(cmap_params['extend'], 'both')
+        self.assertIsNone(cmap_params['levels'])
+        self.assertIsNone(cmap_params['cnorm'])
 
     def test_center(self):
         data = np.random.RandomState(2).rand(100)
-        vmin, vmax, cmap, extend, levels, cnorm = _determine_cmap_params(
-            data, center=0.5)
-        self.assertEqual(vmax - 0.5, 0.5 - vmin)
-        self.assertEqual(cmap, 'RdBu_r')
-        self.assertEqual(extend, 'neither')
-        self.assertIsNone(levels)
-        self.assertIsNone(cnorm)
+        cmap_params = _determine_cmap_params(data, center=0.5)
+        self.assertEqual(cmap_params['vmax'] - 0.5, 0.5 - cmap_params['vmin'])
+        self.assertEqual(cmap_params['cmap'], 'RdBu_r')
+        self.assertEqual(cmap_params['extend'], 'neither')
+        self.assertIsNone(cmap_params['levels'])
+        self.assertIsNone(cmap_params['cnorm'])
 
     def test_integer_levels(self):
         data = 1 + np.random.RandomState(3).rand(100)
-        vmin, vmax, cmap, extend, levels, cnorm = _determine_cmap_params(
-            data, levels=5, vmin=0, vmax=5, cmap='Blues')
-        self.assertEqual(vmin, levels[0])
-        self.assertEqual(vmax, levels[-1])
-        self.assertEqual(cmap.name, 'Blues')
-        self.assertEqual(extend, 'neither')
-        self.assertEqual(cmap.N, 5)
-        self.assertEqual(cnorm.N, 6)
+        cmap_params = _determine_cmap_params(data, levels=5, vmin=0, vmax=5,
+                                             cmap='Blues')
+        self.assertEqual(cmap_params['vmin'], cmap_params['levels'][0])
+        self.assertEqual(cmap_params['vmax'], cmap_params['levels'][-1])
+        self.assertEqual(cmap_params['cmap'].name, 'Blues')
+        self.assertEqual(cmap_params['extend'], 'neither')
+        self.assertEqual(cmap_params['cmap'].N, 5)
+        self.assertEqual(cmap_params['cnorm'].N, 6)
 
-        vmin, vmax, cmap, extend, levels, cnorm = _determine_cmap_params(
-            data, levels=5, vmin=0.5, vmax=1.5)
-        self.assertEqual(cmap.name, 'viridis')
-        self.assertEqual(extend, 'max')
+        cmap_params = _determine_cmap_params(data, levels=5,
+                                             vmin=0.5, vmax=1.5)
+        self.assertEqual(cmap_params['cmap'].name, 'viridis')
+        self.assertEqual(cmap_params['extend'], 'max')
 
     def test_list_levels(self):
         data = 1 + np.random.RandomState(3).rand(100)
 
         orig_levels = [0, 1, 2, 3, 4, 5]
         # vmin and vmax should be ignored if levels are explicitly provided
-        vmin, vmax, cmap, extend, levels, cnorm = _determine_cmap_params(
-            data, levels=orig_levels, vmin=0, vmax=3)
-        self.assertEqual(vmin, 0)
-        self.assertEqual(vmax, 5)
-        self.assertEqual(cmap.N, 5)
-        self.assertEqual(cnorm.N, 6)
+        cmap_params = _determine_cmap_params(data, levels=orig_levels,
+                                             vmin=0, vmax=3)
+        self.assertEqual(cmap_params['vmin'], 0)
+        self.assertEqual(cmap_params['vmax'], 5)
+        self.assertEqual(cmap_params['cmap'].N, 5)
+        self.assertEqual(cmap_params['cnorm'].N, 6)
 
         for wrap_levels in [list, np.array, pd.Index, DataArray]:
-            vmin, vmax, cmap, extend, levels, cnorm = _determine_cmap_params(
+            cmap_params = _determine_cmap_params(
                 data, levels=wrap_levels(orig_levels))
-            self.assertArrayEqual(levels, orig_levels)
+            self.assertArrayEqual(cmap_params['levels'], orig_levels)
 
 
 @requires_matplotlib

--- a/xray/test/test_plot.py
+++ b/xray/test/test_plot.py
@@ -193,7 +193,7 @@ class TestDetermineDiscreteCmapParams(TestCase):
         self.assertEqual(cmap.N, levels)
         self.assertEqual(cnorm.N, levels + 1)
         self.assertEqual(cnorm.vmin, vmin)
-        self.assertEqual(cnorm.vmax, vmax)
+        self.assertEqual(cnorm.vmax, vmax + 10 * np.finfo(float).eps)
 
         cmap, cnorm = _determine_discrete_cmap_params('Blues', levels,
                                                       vmin, vmax, 'both')
@@ -201,7 +201,7 @@ class TestDetermineDiscreteCmapParams(TestCase):
         self.assertEqual(cmap.N, levels)
         self.assertEqual(cnorm.N, levels + 1)
         self.assertEqual(cnorm.vmin, vmin)
-        self.assertEqual(cnorm.vmax, vmax)
+        self.assertEqual(cnorm.vmax, vmax + 10 * np.finfo(float).eps)
 
     def test_list_levels(self):
         levels = [-4, -2, 0, 2, 4]

--- a/xray/test/test_plot.py
+++ b/xray/test/test_plot.py
@@ -257,15 +257,15 @@ class TestDiscreteColorMap(TestCase):
                                ('neither', [0, 5, 10, 15]),
                                ('min', [2, 5, 10, 15])]:
             for kind in ['imshow', 'pcolormesh', 'contourf', 'contour']:
-                primative = getattr(self.darray.plot, kind)(levels=levels)
-                self.assertArrayEqual(levels, primative.norm.boundaries)
-                self.assertEqual(max(levels), primative.norm.vmax)
-                self.assertEqual(min(levels), primative.norm.vmin)
+                primitive = getattr(self.darray.plot, kind)(levels=levels)
+                self.assertArrayEqual(levels, primitive.norm.boundaries)
+                self.assertEqual(max(levels), primitive.norm.vmax)
+                self.assertEqual(min(levels), primitive.norm.vmin)
                 if kind != 'contour':
-                    self.assertEqual(extend, primative.cmap.colorbar_extend)
+                    self.assertEqual(extend, primitive.cmap.colorbar_extend)
                 else:
-                    self.assertEqual('neither', primative.cmap.colorbar_extend)
-                self.assertEqual(len(levels) - 1, len(primative.cmap.colors))
+                    self.assertEqual('neither', primitive.cmap.colorbar_extend)
+                self.assertEqual(len(levels) - 1, len(primitive.cmap.colors))
 
     def test_discrete_colormap_int_levels(self):
         for extend, levels, vmin, vmax in [('neither', 7, None, None),
@@ -273,30 +273,30 @@ class TestDiscreteColorMap(TestCase):
                                            ('both', 7, 4, 8),
                                            ('min', 10, 4, 15)]:
             for kind in ['imshow', 'pcolormesh', 'contourf', 'contour']:
-                primative = getattr(self.darray.plot, kind)(levels=levels,
+                primitive = getattr(self.darray.plot, kind)(levels=levels,
                                                             vmin=vmin,
                                                             vmax=vmax)
                 self.assertGreaterEqual(levels,
-                                        len(primative.norm.boundaries) - 1)
+                                        len(primitive.norm.boundaries) - 1)
                 if vmax is None:
-                    self.assertGreaterEqual(primative.norm.vmax, self.data_max)
+                    self.assertGreaterEqual(primitive.norm.vmax, self.data_max)
                 else:
-                    self.assertGreaterEqual(primative.norm.vmax, vmax)
+                    self.assertGreaterEqual(primitive.norm.vmax, vmax)
                 if vmin is None:
-                    self.assertLessEqual(primative.norm.vmin, self.data_min)
+                    self.assertLessEqual(primitive.norm.vmin, self.data_min)
                 else:
-                    self.assertLessEqual(primative.norm.vmin, vmin)
+                    self.assertLessEqual(primitive.norm.vmin, vmin)
                 if kind != 'contour':
-                    self.assertEqual(extend, primative.cmap.colorbar_extend)
+                    self.assertEqual(extend, primitive.cmap.colorbar_extend)
                 else:
-                    self.assertEqual('neither', primative.cmap.colorbar_extend)
-                self.assertGreaterEqual(levels, len(primative.cmap.colors))
+                    self.assertEqual('neither', primitive.cmap.colorbar_extend)
+                self.assertGreaterEqual(levels, len(primitive.cmap.colors))
 
     def test_discrete_colormap_list_levels_and_vmin_or_vmax(self):
         levels = [0, 5, 10, 15]
-        primative = self.darray.plot(levels=levels, vmin=-3, vmax=20)
-        self.assertEqual(primative.norm.vmax, max(levels))
-        self.assertEqual(primative.norm.vmin, min(levels))
+        primitive = self.darray.plot(levels=levels, vmin=-3, vmax=20)
+        self.assertEqual(primitive.norm.vmax, max(levels))
+        self.assertEqual(primitive.norm.vmin, min(levels))
 
 
 class Common2dMixin:

--- a/xray/test/test_plot.py
+++ b/xray/test/test_plot.py
@@ -6,7 +6,8 @@ from xray import DataArray
 import xray.plot as xplt
 from xray.plot.plot import (_infer_interval_breaks,
                             _determine_cmap_params,
-                            _build_discrete_cmap)
+                            _build_discrete_cmap,
+                            _color_palette)
 
 from . import TestCase, requires_matplotlib
 
@@ -217,6 +218,85 @@ class TestDetermineCmapParams(TestCase):
             vmin, vmax, cmap, extend, levels, cnorm = _determine_cmap_params(
                 data, levels=wrap_levels(orig_levels))
             self.assertArrayEqual(levels, orig_levels)
+
+
+@requires_matplotlib
+class TestDiscreteColorMap(TestCase):
+    def setUp(self):
+        x = np.arange(start=0, stop=10, step=2)
+        y = np.arange(start=9, stop=-7, step=-3)
+        xy = np.dstack(np.meshgrid(x, y))
+        distance = np.linalg.norm(xy, axis=2)
+        self.darray = DataArray(distance, list(zip(('y', 'x'), (y, x))))
+        self.data_min = distance.min()
+        self.data_max = distance.max()
+
+    def test_recover_from_seaborn_jet_exception(self):
+        pal = _color_palette('jet', 4)
+        self.assertTrue(type(pal) == np.ndarray)
+        self.assertEqual(len(pal), 4)
+
+    def test_build_discrete_cmap(self):
+        for (cmap, levels, extend, filled) in [('jet', [0, 1], 'both', False),
+                                               ('hot', [-4, 4], 'max', True)]:
+            ncmap, cnorm = _build_discrete_cmap(cmap, levels, extend, filled)
+            self.assertEqual(ncmap.N, len(levels) - 1)
+            self.assertEqual(len(ncmap.colors), len(levels) - 1)
+            self.assertEqual(cnorm.N, len(levels))
+            self.assertArrayEqual(cnorm.boundaries, levels)
+            self.assertEqual(max(levels), cnorm.vmax)
+            self.assertEqual(min(levels), cnorm.vmin)
+            if filled:
+                self.assertEqual(ncmap.colorbar_extend, extend)
+            else:
+                self.assertEqual(ncmap.colorbar_extend, 'neither')
+
+    def test_discrete_colormap_list_of_levels(self):
+        for extend, levels in [('max', [-1, 2, 4, 8, 10]),
+                               ('both', [2, 5, 10, 11]),
+                               ('neither', [0, 5, 10, 15]),
+                               ('min', [2, 5, 10, 15])]:
+            for kind in ['imshow', 'pcolormesh', 'contourf', 'contour']:
+                primative = getattr(self.darray.plot, kind)(levels=levels)
+                self.assertArrayEqual(levels, primative.norm.boundaries)
+                self.assertEqual(max(levels), primative.norm.vmax)
+                self.assertEqual(min(levels), primative.norm.vmin)
+                if kind != 'contour':
+                    self.assertEqual(extend, primative.cmap.colorbar_extend)
+                else:
+                    self.assertEqual('neither', primative.cmap.colorbar_extend)
+                self.assertEqual(len(levels) - 1, len(primative.cmap.colors))
+
+    def test_discrete_colormap_int_levels(self):
+        for extend, levels, vmin, vmax in [('neither', 7, None, None),
+                                           ('neither', 7, None, 20),
+                                           ('both', 7, 4, 8),
+                                           ('min', 10, 4, 15)]:
+            for kind in ['imshow', 'pcolormesh', 'contourf', 'contour']:
+                primative = getattr(self.darray.plot, kind)(levels=levels,
+                                                            vmin=vmin,
+                                                            vmax=vmax)
+                self.assertGreaterEqual(levels,
+                                        len(primative.norm.boundaries) - 1)
+                if vmax is None:
+                    self.assertGreaterEqual(primative.norm.vmax, self.data_max)
+                else:
+                    self.assertGreaterEqual(primative.norm.vmax, vmax)
+                if vmin is None:
+                    self.assertLessEqual(primative.norm.vmin, self.data_min)
+                else:
+                    self.assertLessEqual(primative.norm.vmin, vmin)
+                if kind != 'contour':
+                    self.assertEqual(extend, primative.cmap.colorbar_extend)
+                else:
+                    self.assertEqual('neither', primative.cmap.colorbar_extend)
+                self.assertGreaterEqual(levels, len(primative.cmap.colors))
+
+    def test_discrete_colormap_list_levels_and_vmin_or_vmax(self):
+        levels = [0, 5, 10, 15]
+        primative = self.darray.plot(levels=levels, vmin=-3, vmax=20)
+        self.assertEqual(primative.norm.vmax, max(levels))
+        self.assertEqual(primative.norm.vmin, min(levels))
 
 
 class Common2dMixin:


### PR DESCRIPTION
This PR adds a discrete colormap / colorbar option to xray plots.

closes #500 

```python
import matplotlib.pyplot as plt
import numpy as np
import xray

# sample DataArray
x = np.arange(start=0, stop=10, step=2)
y = np.arange(start=9, stop=-7, step=-3)
xy = np.dstack(np.meshgrid(x, y))
distance = np.linalg.norm(xy, axis=2)
distance = xray.DataArray(distance, list(zip(('y', 'x'), (y, x))))

# Sample plots
fig, axes = plt.subplots(2, 2, figsize=(8, 8), sharex=True, sharey=True)
distance.plot(ax=axes[0, 0])
axes[0, 0].set_title('Default')
distance.plot(vmin=0, vmax=12, levels=6, ax=axes[1, 0])
axes[1, 0].set_title('Setting with integer levels')
distance.plot(levels=[1, 2, 4, 5, 7, 9], extend='both', cmap='Spectral', ax=axes[0, 1])
axes[0, 1].set_title('Setting with list of levels')
flatui = ["#9b59b6", "#3498db", "#95a5a6", "#e74c3c", "#34495e", "#2ecc71"]
distance.plot(levels=[1, 2, 4, 5, 7], cmap=flatui, extend='both', ax=axes[1, 1])
axes[1, 1].set_title('Using custom list of colors')
```
Produces these plots:

![discrete_example](https://cloud.githubusercontent.com/assets/2443309/9027555/93d8220c-390e-11e5-8184-9f1b75b9ebfe.png)

There are potential issues that I'd still like to look into a bit further.

1.  Does discretizing `cmap` impact the `contour` and `contourf` plot types? We may need some logic to only discretize when the plot type is `imshow` or `pcolormesh`.
2.  It is possible, in some cases, to end up masking out values equal to `vmax`:
    ```python
    distance.plot(levels=6)
    ```
    Produces this plot:

    ![missing_corner](https://cloud.githubusercontent.com/assets/2443309/9027585/0e5ea5f4-3910-11e5-911a-7be312a59876.png)

    In the first example, we corrected for this by setting `extend='max'`.