### PR TITLE
added to_masked_array method and masked_array property 

### DIFF
--- a/doc/api.rst
+++ b/doc/api.rst
@@ -165,7 +165,6 @@ Attributes
 
    DataArray.values
    DataArray.data
-   DataArray.masked_array
    DataArray.coords
    DataArray.dims
    DataArray.name

--- a/doc/api.rst
+++ b/doc/api.rst
@@ -165,6 +165,7 @@ Attributes
 
    DataArray.values
    DataArray.data
+   DataArray.masked_array
    DataArray.coords
    DataArray.dims
    DataArray.name
@@ -373,6 +374,7 @@ DataArray methods
    DataArray.to_series
    DataArray.to_dataframe
    DataArray.to_index
+   DataArray.to_masked_array
    DataArray.to_cdms2
    DataArray.from_series
    DataArray.from_cdms2

--- a/doc/whats-new.rst
+++ b/doc/whats-new.rst
@@ -74,7 +74,7 @@ v0.5.3 (unreleased)
     ds.distance.where(ds.distance < 100).plot()
 
 - New :py:meth:`~xray.DataArray.to_masked_array` convenience method for
-  returning a numpy.ma.MaskedArray.  The :py:attr:`~xray.DataArray.masked_array` property was also added yielding a view of the DataArray via a MaskedArray.
+  returning a numpy.ma.MaskedArray.
 
   .. ipython:: python
 

--- a/doc/whats-new.rst
+++ b/doc/whats-new.rst
@@ -73,6 +73,16 @@ v0.5.3 (unreleased)
     @savefig where_example.png width=4in height=4in
     ds.distance.where(ds.distance < 100).plot()
 
+- New :py:meth:`~xray.DataArray.to_masked_array` convenience method for
+  returning a numpy.ma.MaskedArray.  The :py:attr:`~xray.DataArray.masked_array` property was also added yielding a view of the DataArray via a MaskedArray.
+
+  .. ipython:: python
+
+    da = xray.DataArray(np.random.random_sample(size=(5, 4)))
+    da.where(da < 0.5)
+    da.where(da < 0.5).to_masked_array(copy=True)
+
+
 Bug fixes
 ~~~~~~~~~
 

--- a/xray/core/dataarray.py
+++ b/xray/core/dataarray.py
@@ -334,11 +334,6 @@ class DataArray(AbstractArray, BaseDataObject):
         """The array's data as a numpy.ndarray"""
         return self.variable.values
 
-    @property
-    def masked_array(self):
-        """The array's data as a numpy.ma.MaskedArray"""
-        return self.to_masked_array(copy=False)
-
     @values.setter
     def values(self, value):
         self.variable.values = value
@@ -932,7 +927,8 @@ class DataArray(AbstractArray, BaseDataObject):
         result : MaskedArray
             Masked where invalid values (nan or inf) occur.
         """
-        return np.ma.masked_invalid(self.values, copy=copy)
+        isnull = pd.isnull(self.values)
+        return np.ma.masked_where(isnull, self.values, copy=copy)
 
     @classmethod
     def from_series(cls, series):

--- a/xray/core/dataarray.py
+++ b/xray/core/dataarray.py
@@ -919,8 +919,8 @@ class DataArray(AbstractArray, BaseDataObject):
         Parameters
         ----------
         copy : bool
-            If True (default) make a copy of the array in the result. If False
-            modify array in place and return a view.
+            If True (default) make a copy of the array in the result. If False,
+            a MaskedArray view of DataArray.values is returned.
 
         Returns
         -------

--- a/xray/core/dataarray.py
+++ b/xray/core/dataarray.py
@@ -2,6 +2,7 @@ import contextlib
 import functools
 import warnings
 
+import numpy as np
 import pandas as pd
 
 from ..plot.plot import _PlotMethods
@@ -332,6 +333,11 @@ class DataArray(AbstractArray, BaseDataObject):
     def values(self):
         """The array's data as a numpy.ndarray"""
         return self.variable.values
+
+    @property
+    def masked_array(self):
+        """The array's data as a numpy.ma.MaskedArray"""
+        return self.to_masked_array(copy=False)
 
     @values.setter
     def values(self, value):
@@ -911,6 +917,22 @@ class DataArray(AbstractArray, BaseDataObject):
         """
         index = self.coords.to_index()
         return pd.Series(self.values.reshape(-1), index=index, name=self.name)
+
+    def to_masked_array(self, copy=True):
+        """Convert this array into a numpy.ma.MaskedArray
+
+        Parameters
+        ----------
+        copy : bool
+            If True (default) make a copy of the array in the result. If False
+            modify array in place and return a view.
+
+        Returns
+        -------
+        result : MaskedArray
+            Masked where invalid values (nan or inf) occur.
+        """
+        return np.ma.masked_invalid(self.values, copy=copy)
 
     @classmethod
     def from_series(cls, series):

--- a/xray/plot/plot.py
+++ b/xray/plot/plot.py
@@ -429,7 +429,7 @@ def _plot2d(plotfunc):
         # some plotting functions only know how to handle ndarrays
         x = darray[xlab].values
         y = darray[ylab].values
-        z = np.ma.MaskedArray(darray.values, pd.isnull(darray.values))
+        z = darray.masked_array
 
         _ensure_plottable(x, y)
 

--- a/xray/plot/plot.py
+++ b/xray/plot/plot.py
@@ -429,7 +429,7 @@ def _plot2d(plotfunc):
         # some plotting functions only know how to handle ndarrays
         x = darray[xlab].values
         y = darray[ylab].values
-        z = darray.masked_array
+        z = darray.to_masked_array(copy=False)
 
         _ensure_plottable(x, y)
 

--- a/xray/test/test_dataarray.py
+++ b/xray/test/test_dataarray.py
@@ -1351,13 +1351,13 @@ class TestDataArray(TestCase):
         self.assertEqual(masked_array[0, 0], 10.)
         self.assertEqual(da[0, 0].values, 10.)
         self.assertTrue(masked_array.base is da.values)
-        self.assertTrue(isinstance(masked_array, np.ma.MaskedArray))
+        self.assertIsInstance(masked_array, np.ma.MaskedArray)
 
         # Test with some odd arrays
         for v in [4, np.nan, True, '4', 'four']:
             da = DataArray(v)
             ma = da.to_masked_array()
-            self.assertTrue(isinstance(ma, np.ma.MaskedArray))
+            self.assertIsInstance(ma, np.ma.MaskedArray)
 
     def test_to_and_from_cdms2(self):
         try:

--- a/xray/test/test_dataarray.py
+++ b/xray/test/test_dataarray.py
@@ -51,8 +51,6 @@ class TestDataArray(TestCase):
             self.ds['foo'].to_index()
         with self.assertRaises(AttributeError):
             self.dv.variable = self.v
-        self.assertTrue(self.dv.masked_array.base is self.dv.values)
-        self.assertTrue(isinstance(self.dv.masked_array, np.ma.MaskedArray))
 
     def test_name(self):
         arr = self.dv
@@ -1356,14 +1354,10 @@ class TestDataArray(TestCase):
         self.assertTrue(isinstance(masked_array, np.ma.MaskedArray))
 
         # Test with some odd arrays
-        for v in [4, np.nan, True]:
+        for v in [4, np.nan, True, '4', 'four']:
             da = DataArray(v)
             ma = da.to_masked_array()
             self.assertTrue(isinstance(ma, np.ma.MaskedArray))
-        for v in ['4', 'four']:
-            da = DataArray(v)
-            with self.assertRaisesRegexp(TypeError, 'Not implemented for'):
-                ma = da.to_masked_array()
 
     def test_to_and_from_cdms2(self):
         try:


### PR DESCRIPTION
This PR adds convienience methods to convert DataArrays to numpy masked arrays.

`DataArray.to_masked_array(copy=True)` returns a numpy Masked array 

`DataArray.masked_array` returns a masked array that is a view to the `DataArray.values.`

closes #460 