### PR TITLE
Bug when encoding datetime64 with NaT as first value

### DIFF
--- a/doc/whats-new.rst
+++ b/doc/whats-new.rst
@@ -90,6 +90,8 @@ Bug fixes
   bottleneck is installed (:issue:`489`).
 - Dataset aggregation functions dropped variables with unsigned integer dtype
   (:issue:`505`).
+- Fixed an error when attempting to saving datetime64 variables to netCDF
+  files when the first element is ``NaT``.
 
 v0.5.2 (16 July 2015)
 ---------------------

--- a/xray/conventions.py
+++ b/xray/conventions.py
@@ -189,9 +189,11 @@ def infer_datetime_units(dates):
     unique time deltas in `dates`)
     """
     dates = pd.to_datetime(np.asarray(dates).ravel(), box=False)
-    unique_timedeltas = np.unique(np.diff(dates[pd.notnull(dates)]))
+    dates = dates[pd.notnull(dates)]
+    unique_timedeltas = np.unique(np.diff(dates))
     units = _infer_time_units_from_diff(unique_timedeltas)
-    return '%s since %s' % (units, pd.Timestamp(dates[0]))
+    reference_date = dates[0] if len(dates) > 0 else '1970-01-01'
+    return '%s since %s' % (units, pd.Timestamp(reference_date))
 
 
 def infer_timedelta_units(deltas):
@@ -253,7 +255,7 @@ def cast_to_int_if_safe(num):
 
 def encode_cf_datetime(dates, units=None, calendar=None):
     """Given an array of datetime objects, returns the tuple `(num, units,
-    calendar)` suitable for a CF complient time variable.
+    calendar)` suitable for a CF compliant time variable.
 
     Unlike `date2num`, this function can handle datetime64 arrays.
 

--- a/xray/test/test_conventions.py
+++ b/xray/test/test_conventions.py
@@ -357,7 +357,12 @@ class TestDatetime(TestCase):
                                  'days since 1900-01-01 00:00:00'),
                                 (pd.to_datetime(['1900-01-01',
                                                  '1900-01-02T00:00:00.005']),
-                                 'seconds since 1900-01-01 00:00:00')]:
+                                 'seconds since 1900-01-01 00:00:00'),
+                                (pd.to_datetime(['NaT', '1900-01-01']),
+                                 'days since 1900-01-01 00:00:00'),
+                                (pd.to_datetime(['NaT']),
+                                 'days since 1970-01-01 00:00:00'),
+                                ]:
             self.assertEqual(expected, conventions.infer_datetime_units(dates))
 
     def test_cf_timedelta(self):


### PR DESCRIPTION
Thanks @hdail for the report