### PR TITLE
BUG: .all() and .any() are now lazy on dask arrays

### DIFF
--- a/doc/whats-new.rst
+++ b/doc/whats-new.rst
@@ -90,6 +90,8 @@ Bug fixes
   bottleneck is installed (:issue:`489`).
 - Dataset aggregation functions dropped variables with unsigned integer dtype
   (:issue:`505`).
+- ``.any()`` and ``.all()`` were not lazy when used on xray objects containing
+  dask arrays.
 - Fixed an error when attempting to saving datetime64 variables to netCDF
   files when the first element is ``NaT``.
 

--- a/xray/core/ops.py
+++ b/xray/core/ops.py
@@ -43,7 +43,7 @@ NUMPY_SAME_METHODS = ['item', 'searchsorted']
 NUMPY_UNARY_METHODS = ['astype', 'argsort', 'clip', 'conj', 'conjugate']
 PANDAS_UNARY_FUNCTIONS = ['isnull', 'notnull']
 # methods which remove an axis
-NUMPY_REDUCE_METHODS = ['all', 'any']
+REDUCE_METHODS = ['all', 'any']
 NAN_REDUCE_METHODS = ['argmax', 'argmin', 'max', 'min', 'mean', 'prod', 'sum',
                       'std', 'var', 'median']
 # TODO: wrap cumprod/cumsum, take, dot, sort
@@ -83,6 +83,10 @@ broadcast_to = _dask_or_eager_func('broadcast_to', npcompat)
 
 concatenate = _dask_or_eager_func('concatenate', dispatch_elemwise=True)
 stack = _dask_or_eager_func('stack', npcompat, dispatch_elemwise=True)
+
+array_all = _dask_or_eager_func('all')
+array_any = _dask_or_eager_func('any')
+
 
 
 def _interleaved_indices_required(indices):
@@ -372,8 +376,8 @@ def last(values, axis, skipna=None):
 
 
 def inject_reduce_methods(cls):
-    methods = ([(name, getattr(np, name), False) for name
-               in NUMPY_REDUCE_METHODS]
+    methods = ([(name, globals()['array_%s' % name], False) for name
+               in REDUCE_METHODS]
                + [(name, globals()[name], True) for name
                   in NAN_REDUCE_METHODS]
                + [('count', count, False)])

--- a/xray/test/test_dask.py
+++ b/xray/test/test_dask.py
@@ -124,6 +124,8 @@ class TestVariable(DaskTestCase):
         self.assertLazyAndAllClose(u.mean(), v.mean())
         self.assertLazyAndAllClose(u.std(), v.std())
         self.assertLazyAndAllClose(u.argmax(dim='x'), v.argmax(dim='x'))
+        self.assertLazyAndAllClose((u > 1).any(), (v > 1).any())
+        self.assertLazyAndAllClose((u < 1).all('x'), (v < 1).all('x'))
         with self.assertRaisesRegexp(NotImplementedError, 'dask'):
             v.prod()
         with self.assertRaisesRegexp(NotImplementedError, 'dask'):


### PR DESCRIPTION
Previously, they would work by loading the arrays into memory.