### PR TITLE
fixes #534- use core.formatting.format_item for slice title

### DIFF
--- a/xray/core/dataarray.py
+++ b/xray/core/dataarray.py
@@ -19,6 +19,7 @@ from .dataset import Dataset
 from .pycompat import iteritems, basestring, OrderedDict, zip
 from .utils import FrozenOrderedDict
 from .variable import as_variable, _as_compatible_data, Coordinate
+from .formatting import format_item
 
 
 def _infer_coords_and_dims(shape, coords, dims):
@@ -1106,7 +1107,7 @@ class DataArray(AbstractArray, BaseDataObject):
 
     def _title_for_slice(self, truncate=50):
         '''
-        If the dataarray has 1 dimensional coordiantes or comes from a slice
+        If the dataarray has 1 dimensional coordinates or comes from a slice
         we can show that info in the title
 
         Parameters
@@ -1118,11 +1119,13 @@ class DataArray(AbstractArray, BaseDataObject):
         -------
         title : string
             Can be used for plot titles
+
         '''
         one_dims = []
         for dim, coord in iteritems(self.coords):
             if coord.size == 1:
-                one_dims.append('{dim} = {v}'.format(dim=dim, v=coord.values))
+                one_dims.append('{dim} = {v}'.format(dim=dim,
+                    v=format_item(coord.values)))
 
         title = ', '.join(one_dims)
         if len(title) > truncate:


### PR DESCRIPTION
Closes #534

The `formatting` for the `__repr__` work perfectly for this.

Didn't write any tests since it seems better to directly test the formatting module here. 

![image](https://cloud.githubusercontent.com/assets/5356122/9392020/fe2a98c8-472e-11e5-8646-f2c95e04cb64.png)
