### PR TITLE
robust plot documentation

### DIFF
--- a/doc/plotting.rst
+++ b/doc/plotting.rst
@@ -250,8 +250,11 @@ washing out the plot.
     @savefig plotting_robust1.png width=4in
     air_outliers.plot()
 
-To remedy this use the parameter ``robust=True`` to use robust percentiles
-for computing the color limits.
+This plot shows that we have outliers. The easy way to visualize
+the data without the outliers is to pass the parameter
+``robust=True``.
+This will use the 2nd and 98th
+percentiles of the data to compute the color limits.
 
 .. ipython:: python
 

--- a/doc/plotting.rst
+++ b/doc/plotting.rst
@@ -234,6 +234,31 @@ example, consider the original data in Kelvins rather than Celsius:
 The Celsius data contain 0, so a diverging color map was used. The
 Kelvins do not have 0, so the default color map was used.
 
+Robust
+~~~~~~
+
+Outliers often have an extreme effect on the output of the plot.
+Here we add two bad data points. This affects the color scale,
+washing out the plot.
+
+.. ipython:: python
+
+    air_outliers = airtemps.air.isel(time=0).copy()
+    air_outliers[0, 0] = 100
+    air_outliers[-1, -1] = 400
+
+    @savefig plotting_robust1.png width=4in
+    air_outliers.plot()
+
+To remedy this use the parameter ``robust=True`` to use robust percentiles
+for computing the color limits.
+
+.. ipython:: python
+
+    @savefig plotting_robust2.png width=4in
+    air_outliers.plot(robust=True)
+
+
 Discrete Colormaps
 ~~~~~~~~~~~~~~~~~~
 

--- a/doc/plotting.rst
+++ b/doc/plotting.rst
@@ -261,6 +261,9 @@ percentiles of the data to compute the color limits.
     @savefig plotting_robust2.png width=4in
     air_outliers.plot(robust=True)
 
+Observe that the ranges of the color bar have changed. The arrows on the
+color bar indicate
+that the colors include data points outside the bounds.
 
 Discrete Colormaps
 ~~~~~~~~~~~~~~~~~~

--- a/xray/plot/plot.py
+++ b/xray/plot/plot.py
@@ -211,21 +211,21 @@ def _update_axes_limits(ax, xincrease, yincrease):
 
 def _determine_cmap_params(plot_data, vmin=None, vmax=None, cmap=None,
                            center=None, robust=False, extend=None,
-                           levels=None, filled=True, cnorm=None,
-                           robust_percentile=2):
+                           levels=None, filled=True, cnorm=None):
     """
     Use some heuristics to set good defaults for colorbar and range.
 
     Adapted from Seaborn:
     https://github.com/mwaskom/seaborn/blob/v0.6/seaborn/matrix.py#L158
     """
+    ROBUST_PERCENTILE = 2.0
     import matplotlib as mpl
 
     calc_data = plot_data[~pd.isnull(plot_data)]
     if vmin is None:
-        vmin = np.percentile(calc_data, robust_percentile) if robust else calc_data.min()
+        vmin = np.percentile(calc_data, ROBUST_PERCENTILE) if robust else calc_data.min()
     if vmax is None:
-        vmax = np.percentile(calc_data, 100 - robust_percentile) if robust else calc_data.max()
+        vmax = np.percentile(calc_data, 100 - ROBUST_PERCENTILE) if robust else calc_data.max()
 
     # Simple heuristics for whether these data should  have a divergent map
     divergent = ((vmin < 0) and (vmax > 0)) or center is not None
@@ -445,8 +445,7 @@ def _plot2d(plotfunc):
         filled = plotfunc.__name__ != 'contour'
 
         cmap_params = _determine_cmap_params(z.data, vmin, vmax, cmap, center,
-                                             robust, extend, levels,
-                                             filled, robust_percentile=2)
+                                             robust, extend, levels, filled)
 
         if 'contour' in plotfunc.__name__:
             # extend is a keyword argument only for contour and contourf, but

--- a/xray/plot/plot.py
+++ b/xray/plot/plot.py
@@ -211,7 +211,8 @@ def _update_axes_limits(ax, xincrease, yincrease):
 
 def _determine_cmap_params(plot_data, vmin=None, vmax=None, cmap=None,
                            center=None, robust=False, extend=None,
-                           levels=None, filled=True, cnorm=None):
+                           levels=None, filled=True, cnorm=None,
+                           robust_percentile=2):
     """
     Use some heuristics to set good defaults for colorbar and range.
 
@@ -222,9 +223,9 @@ def _determine_cmap_params(plot_data, vmin=None, vmax=None, cmap=None,
 
     calc_data = plot_data[~pd.isnull(plot_data)]
     if vmin is None:
-        vmin = np.percentile(calc_data, 2) if robust else calc_data.min()
+        vmin = np.percentile(calc_data, robust_percentile) if robust else calc_data.min()
     if vmax is None:
-        vmax = np.percentile(calc_data, 98) if robust else calc_data.max()
+        vmax = np.percentile(calc_data, 100 - robust_percentile) if robust else calc_data.max()
 
     # Simple heuristics for whether these data should  have a divergent map
     divergent = ((vmin < 0) and (vmax > 0)) or center is not None
@@ -392,7 +393,7 @@ def _plot2d(plotfunc):
         use of a diverging colormap.
     robust : bool, optional
         If True and ``vmin`` or ``vmax`` are absent, the colormap range is
-        computed with robust quantiles instead of the extreme values.
+        computed with 2nd and 98th percentiles instead of the extreme values.
     extend : {'neither', 'both', 'min', 'max'}, optional
         How to draw arrows extending the colorbar beyond its limits. If not
         provided, extend is inferred from vmin, vmax and the data limits.
@@ -444,7 +445,8 @@ def _plot2d(plotfunc):
         filled = plotfunc.__name__ != 'contour'
 
         cmap_params = _determine_cmap_params(z.data, vmin, vmax, cmap, center,
-                                             robust, extend, levels, filled)
+                                             robust, extend, levels,
+                                             filled, robust_percentile=2)
 
         if 'contour' in plotfunc.__name__:
             # extend is a keyword argument only for contour and contourf, but


### PR DESCRIPTION
These are the plots that will be in the docs.

## default

![image](https://cloud.githubusercontent.com/assets/5356122/9449387/1d1f27e6-4a57-11e5-93cf-47f0fedcb222.png)

## `robust=True`

![image](https://cloud.githubusercontent.com/assets/5356122/9449396/32b87d0a-4a57-11e5-826e-3ee71d539edb.png)
