### PR TITLE
Fix pcolormesh plots with cartopy

### DIFF
--- a/xray/plot/plot.py
+++ b/xray/plot/plot.py
@@ -623,7 +623,9 @@ def pcolormesh(x, y, z, ax, **kwargs):
 
     # by default, pcolormesh picks "round" values for bounds
     # this results in ugly looking plots with lots of surrounding whitespace
-    ax.set_xlim(x[0], x[-1])
-    ax.set_ylim(y[0], y[-1])
+    if not hasattr(ax, 'projection'):
+        # not a cartopy geoaxis
+        ax.set_xlim(x[0], x[-1])
+        ax.set_ylim(y[0], y[-1])
 
     return ax, primitive

--- a/xray/plot/plot.py
+++ b/xray/plot/plot.py
@@ -304,7 +304,7 @@ def _color_palette(cmap, n_colors):
     elif isinstance(cmap, basestring):
         # we have some sort of named palette
         try:
-            # first try to turn it into a palette with seaborn                    
+            # first try to turn it into a palette with seaborn
             from seaborn.apionly import color_palette
             pal = color_palette(cmap, n_colors=n_colors)
         except (ImportError, ValueError):
@@ -406,7 +406,7 @@ def _plot2d(plotfunc):
         The mapping from data values to color space. If not provided, this
         will be either be ``viridis`` (if the function infers a sequential
         dataset) or ``RdBu_r`` (if the function infers a diverging dataset).
-        When when `Seaborn` is installed, ``cmap`` may also be a `seaborn` 
+        When when `Seaborn` is installed, ``cmap`` may also be a `seaborn`
         color palette. If ``cmap`` is seaborn color palette and the plot type
         is not ``contour`` or ``contourf``, ``levels`` must also be specified.
     colors : discrete colors to plot, optional
@@ -563,9 +563,13 @@ def imshow(x, y, z, ax, **kwargs):
     bottom, top = y[-1] + ystep, y[0] - ystep
 
     defaults = {'extent': [left, right, bottom, top],
-                'aspect': 'auto',
+                'origin': 'upper',
                 'interpolation': 'nearest',
                 }
+
+    if not hasattr(ax, 'projection'):
+        # not for cartopy geoaxes
+        defaults['aspect'] = 'auto'
 
     # Allow user to override these defaults
     defaults.update(kwargs)


### PR DESCRIPTION
```python
proj = ccrs.Orthographic(central_longitude=230, central_latitude=5)
fig, ax = plt.subplots(figsize=(20, 8), subplot_kw=dict(projection=proj))
x.plot.pcolormesh(ax=ax, transform=ccrs.PlateCarree())
ax.coastlines()
```

Before:
![image](https://cloud.githubusercontent.com/assets/1217238/9669158/5149e908-523a-11e5-8d2a-c48326115174.png)

After:
![image](https://cloud.githubusercontent.com/assets/1217238/9669163/556316fe-523a-11e5-8322-d7f92e551d65.png)
