### PR TITLE
Fixed bug with indexing arrays with unicode dtype

### DIFF
--- a/doc/whats-new.rst
+++ b/doc/whats-new.rst
@@ -34,6 +34,7 @@ Bug fixes
 
 - Aggregation functions now correctly skip ``NaN`` for data for ``complex128``
   dtype (:issue:`554`).
+- Fixed indexing 0d arrays with unicode dtype (:issue:`568`).
 
 v0.6.0 (21 August 2015)
 -----------------------

--- a/xray/core/variable.py
+++ b/xray/core/variable.py
@@ -101,7 +101,8 @@ def _as_compatible_data(data, fastpath=False):
         data = np.timedelta64(getattr(data, 'value', data), 'ns')
 
     if (not hasattr(data, 'dtype') or not hasattr(data, 'shape')
-            or isinstance(data, (np.string_, np.datetime64, np.timedelta64))):
+            or isinstance(data, (np.string_, np.unicode_,
+                                 np.datetime64, np.timedelta64))):
         # data must be ndarray-like
         data = np.asarray(data)
 

--- a/xray/test/test_variable.py
+++ b/xray/test/test_variable.py
@@ -599,6 +599,15 @@ class TestVariable(TestCase, VariableSubclassTestCases):
         v = Variable([], np.string_('asdf'))
         self.assertVariableIdentical(v[()], v)
 
+        v = Variable([], np.unicode_(u'asdf'))
+        self.assertVariableIdentical(v[()], v)
+
+    def test_indexing_0d_unicode(self):
+        # regression test for GH568
+        actual = Variable(('x'), [u'tmax'])[0][()]
+        expected = Variable((), u'tmax')
+        self.assertVariableIdentical(actual, expected)
+
     def test_transpose(self):
         v = Variable(['time', 'x'], self.d)
         v2 = Variable(['x', 'time'], self.d.T)


### PR DESCRIPTION
Previous this raised TypeError:

    Variable(('x'), [u'tmax'])[0][()]