### PR TITLE
BUG: ensure xray works with pandas 0.17.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -34,7 +34,7 @@ matrix:
   - python: 2.7
     env: UPDATE_ENV="pip install toolz https://github.com/blaze/dask/archive/master.zip"
   - python: 2.7
-    env: UPDATE_ENV="conda remove pandas && pip install https://github.com/pydata/pandas/archive/master.zip"
+    env: UPDATE_ENV="conda remove pandas && conda install cython && pip install https://github.com/pydata/pandas/archive/master.zip"
   allow_failures:
   - python: 2.7
     env: UPDATE_ENV="pip install pydap"
@@ -48,7 +48,7 @@ matrix:
   - python: 2.7
     env: UPDATE_ENV="pip install toolz https://github.com/blaze/dask/archive/master.zip"
   - python: 2.7
-    env: UPDATE_ENV="conda remove pandas && pip install https://github.com/pydata/pandas/archive/master.zip"
+    env: UPDATE_ENV="conda remove pandas && conda install cython && pip install https://github.com/pydata/pandas/archive/master.zip"
 
 before_install:
   - if [[ "$TRAVIS_PYTHON_VERSION" == "2.7" ]]; then

--- a/.travis.yml
+++ b/.travis.yml
@@ -34,7 +34,7 @@ matrix:
   - python: 2.7
     env: UPDATE_ENV="pip install toolz https://github.com/blaze/dask/archive/master.zip"
   - python: 2.7
-    env: UPDATE_ENV="pip install https://github.com/pydata/pandas/archive/master.zip"
+    env: UPDATE_ENV="conda remove pandas && pip install https://github.com/pydata/pandas/archive/master.zip"
   allow_failures:
   - python: 2.7
     env: UPDATE_ENV="pip install pydap"
@@ -48,7 +48,7 @@ matrix:
   - python: 2.7
     env: UPDATE_ENV="pip install toolz https://github.com/blaze/dask/archive/master.zip"
   - python: 2.7
-    env: UPDATE_ENV="pip install https://github.com/pydata/pandas/archive/master.zip"
+    env: UPDATE_ENV="conda remove pandas && pip install https://github.com/pydata/pandas/archive/master.zip"
 
 before_install:
   - if [[ "$TRAVIS_PYTHON_VERSION" == "2.7" ]]; then

--- a/.travis.yml
+++ b/.travis.yml
@@ -32,7 +32,9 @@ matrix:
         - libnetcdf-dev
     env: UPDATE_ENV="conda install cython && pip install https://github.com/Unidata/netcdf4-python/archive/master.zip"
   - python: 2.7
-    env: UPDATE_ENV="pip install toolz https://github.com/ContinuumIO/dask/archive/master.zip"
+    env: UPDATE_ENV="pip install toolz https://github.com/blaze/dask/archive/master.zip"
+  - python: 2.7
+    env: UPDATE_ENV="pip install https://github.com/pydata/pandas/archive/master.zip"
   allow_failures:
   - python: 2.7
     env: UPDATE_ENV="pip install pydap"
@@ -44,7 +46,9 @@ matrix:
         - libnetcdf-dev
     env: UPDATE_ENV="conda install cython && pip install https://github.com/Unidata/netcdf4-python/archive/master.zip"
   - python: 2.7
-    env: UPDATE_ENV="pip install toolz https://github.com/ContinuumIO/dask/archive/master.zip"
+    env: UPDATE_ENV="pip install toolz https://github.com/blaze/dask/archive/master.zip"
+  - python: 2.7
+    env: UPDATE_ENV="pip install https://github.com/pydata/pandas/archive/master.zip"
 
 before_install:
   - if [[ "$TRAVIS_PYTHON_VERSION" == "2.7" ]]; then

--- a/doc/whats-new.rst
+++ b/doc/whats-new.rst
@@ -32,6 +32,9 @@ Enhancements
 Bug fixes
 ~~~~~~~~~
 
+- Forwards compatibility with the next release of changes (v0.17.0).
+  We were using some internal pandas routines for datetime conversion, which
+  unfortunately have now changed upstream (:issue:`569`).
 - Aggregation functions now correctly skip ``NaN`` for data for ``complex128``
   dtype (:issue:`554`).
 - Fixed indexing 0d arrays with unicode dtype (:issue:`568`).

--- a/xray/core/common.py
+++ b/xray/core/common.py
@@ -418,13 +418,6 @@ def _maybe_promote(dtype):
 
 def _possibly_convert_objects(values):
     """Convert arrays of datetime.datetime and datetime.timedelta objects into
-    datetime64 and timedelta64
+    datetime64 and timedelta64, according to the pandas convention.
     """
-    try:
-        converter = functools.partial(pd.core.common._possibly_convert_objects,
-                                      convert_numeric=False)
-    except AttributeError:
-        # our fault for using a private pandas API that has gone missing
-        # this should do the same coercion (though it will be slower)
-        converter = lambda x: np.asarray(pd.Series(x))
-    return converter(values.ravel()).reshape(values.shape)
+    return np.asarray(pd.Series(values.ravel())).reshape(values.shape)

--- a/xray/core/variable.py
+++ b/xray/core/variable.py
@@ -119,11 +119,11 @@ def _as_compatible_data(data, fastpath=False):
             data = np.asarray(data)
 
     if isinstance(data, np.ndarray):
-        data = common._possibly_convert_objects(data)
-        if data.dtype.kind == 'M':
-            # TODO: automatically cast arrays of datetime objects as well
+        if data.dtype.kind == 'O':
+            data = common._possibly_convert_objects(data)
+        elif data.dtype.kind == 'M':
             data = np.asarray(data, 'datetime64[ns]')
-        if data.dtype.kind == 'm':
+        elif data.dtype.kind == 'm':
             data = np.asarray(data, 'timedelta64[ns]')
 
     return _maybe_wrap_data(data)

--- a/xray/test/test_dask.py
+++ b/xray/test/test_dask.py
@@ -154,11 +154,11 @@ class TestVariable(DaskTestCase):
         try:
             v.argsort()
         except NotImplementedError as err:
-            self.assertIn('dask', err.message)
+            self.assertIn('dask', str(err))
         try:
             v[0].item()
         except NotImplementedError as err:
-            self.assertIn('dask', err.message)
+            self.assertIn('dask', str(err))
 
     def test_ufuncs(self):
         u = self.eager_var

--- a/xray/test/test_dask.py
+++ b/xray/test/test_dask.py
@@ -151,12 +151,14 @@ class TestVariable(DaskTestCase):
 
     def test_missing_methods(self):
         v = self.lazy_var
-        with self.assertRaisesRegexp(NotImplementedError, 'dask'):
-            v.conj()
-        with self.assertRaisesRegexp(NotImplementedError, 'dask'):
+        try:
             v.argsort()
-        with self.assertRaisesRegexp(NotImplementedError, 'dask'):
+        except NotImplementedError as err:
+            self.assertIn('dask', err.message)
+        try:
             v[0].item()
+        except NotImplementedError as err:
+            self.assertIn('dask', err.message)
 
     def test_ufuncs(self):
         u = self.eager_var


### PR DESCRIPTION
We were using some internal routines in pandas to convert object of datetime
objects arrays to datetime64. Predictably, these internal routines have now
changed, breaking xray.

This is definitely my fault but also bad luck -- I had a guard against the
internal function dissappearing, but not against the keyword arguments
changing.

In any case, this fix ensures forwards compatibility with the next release of
pandas, which will be coming out next week.