### PR TITLE
Don't quote strings in FacetGrid titles

### DIFF
--- a/xray/core/formatting.py
+++ b/xray/core/formatting.py
@@ -89,14 +89,14 @@ def format_timedelta(t, timedelta_format=None):
             return timedelta_str
 
 
-def format_item(x, timedelta_format=None):
+def format_item(x, timedelta_format=None, quote_strings=True):
     """Returns a succinct summary of an object as a string"""
     if isinstance(x, (np.datetime64, datetime)):
         return format_timestamp(x)
     if isinstance(x, (np.timedelta64, timedelta)):
         return format_timedelta(x, timedelta_format=timedelta_format)
     elif isinstance(x, (unicode_type, bytes_type)):
-        return repr(x)
+        return repr(x) if quote_strings else x
     elif isinstance(x, (float, np.float)):
         return '{0:.4}'.format(x)
     else:

--- a/xray/plot/facetgrid.py
+++ b/xray/plot/facetgrid.py
@@ -21,7 +21,7 @@ def _nicetitle(coord, value, maxchar, template):
     """
     Put coord, value in template and truncate at maxchar
     """
-    prettyvalue = format_item(value)
+    prettyvalue = format_item(value, quote_strings=False)
     title = template.format(coord=coord, value=prettyvalue)
 
     if len(title) > maxchar:

--- a/xray/test/test_plot.py
+++ b/xray/test/test_plot.py
@@ -456,10 +456,10 @@ class Common2dMixin:
 
     def test_default_title(self):
         a = DataArray(easy_array((4, 3, 2)), dims=['a', 'b', 'c'])
-        a.coords['d'] = 10
+        a.coords['d'] = u'foo'
         self.plotfunc(a.isel(c=1))
         title = plt.gca().get_title()
-        self.assertEqual('c = 1, d = 10', title)
+        self.assertEqual('c = 1, d = foo', title)
 
     def test_colorbar_label(self):
         self.darray.name = 'testvar'


### PR DESCRIPTION
`model = foo` looks better than `model = 'foo'` or `model = u'foo'`.

This is also consistent with what Seaborn does.