### PR TITLE
Handle global attribute with engine='pydap' more consistently

### DIFF
--- a/doc/whats-new.rst
+++ b/doc/whats-new.rst
@@ -49,6 +49,8 @@ Bug fixes
 - :py:meth:`~xray.DataArray.where` now uses dask instead of numpy if either the
   array or ``other`` is a dask array. Previously, if ``other`` was a numpy array
   the method was evaluated eagerly.
+- Global attributes are now handled more consistently when loading remote
+  datasets using ``engine='pydap'`` (:issue:`574`).
 
 v0.6.0 (21 August 2015)
 -----------------------

--- a/xray/backends/pydap_.py
+++ b/xray/backends/pydap_.py
@@ -40,6 +40,16 @@ class PydapArrayWrapper(NDArrayMixin):
         return result
 
 
+def _fix_global_attributes(attributes):
+    attributes = dict(attributes)
+    for k in list(attributes):
+        if k.lower() == 'global' or k.lower().endswith('_global'):
+            # move global attributes to the top level, like the netcdf-C
+            # DAP client
+            attributes.update(attributes.pop(k))
+    return attributes
+
+
 class PydapDataStore(AbstractDataStore):
     """Store for accessing OpenDAP datasets with pydap.
 
@@ -59,7 +69,7 @@ class PydapDataStore(AbstractDataStore):
                                  for k, v in self.ds.iteritems())
 
     def get_attrs(self):
-        return Frozen(self.ds.attributes)
+        return Frozen(_fix_global_attributes(self.ds.attributes))
 
     def get_dimensions(self):
         return Frozen(self.ds.dimensions)

--- a/xray/test/test_backends.py
+++ b/xray/test/test_backends.py
@@ -915,6 +915,10 @@ class PydapTest(TestCase):
         with create_datasets() as (actual, expected):
             self.assertDatasetEqual(actual, expected)
 
+            # global attributes should be global attributes on the dataset
+            self.assertNotIn('NC_GLOBAL', actual.attrs)
+            self.assertIn('history', actual.attrs)
+
         with create_datasets() as (actual, expected):
             self.assertDatasetEqual(actual.isel(l=2), expected.isel(l=2))
 


### PR DESCRIPTION
These should be unpacked as actual global attributes, instead of
being nested dicts under keys like "GLOBAL".

The netcdf4 opendap client already unpacks these attributes.