### PR TITLE
Make where lazy if either argument is a dask array

### DIFF
--- a/doc/whats-new.rst
+++ b/doc/whats-new.rst
@@ -46,6 +46,9 @@ Bug fixes
 - Fixed indexing 0d arrays with unicode dtype (:issue:`568`).
 - :py:meth:`~xray.DataArray.name` and Dataset keys must be a string or None to
   be written to netCDF (:issue:`533`).
+- :py:meth:`~xray.DataArray.where` now uses dask instead of numpy if either the
+  array or ``other`` is a dask array. Previously, if ``other`` was a numpy array
+  the method was evaluated eagerly.
 
 v0.6.0 (21 August 2015)
 -----------------------

--- a/xray/test/test_dask.py
+++ b/xray/test/test_dask.py
@@ -248,6 +248,16 @@ class TestDataArrayAndDataset(DaskTestCase):
         v = self.lazy_array
         self.assertLazyAndAllClose(np.sin(u), xu.sin(v))
 
+    def test_where_dispatching(self):
+        a = np.arange(10)
+        b = a > 3
+        x = da.from_array(a, 5)
+        y = da.from_array(b, 5)
+        expected = DataArray(a).where(b)
+        self.assertLazyAndIdentical(expected, DataArray(a).where(y))
+        self.assertLazyAndIdentical(expected, DataArray(x).where(b))
+        self.assertLazyAndIdentical(expected, DataArray(x).where(y))
+
     def test_simultaneous_compute(self):
         ds = Dataset({'foo': ('x', range(5)),
                       'bar': ('x', range(5))}).chunk()


### PR DESCRIPTION
`where` now uses dask instead of numpy if either the array or ``other`` is a
dask array. Previously, if ``other`` was a numpy array the method was
evaluated eagerly.