### PR TITLE
unsorted integer indexing on netCDF4 objections on disk

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 *.py[cod]
+__pycache__
 
 # C extensions
 *.so


### PR DESCRIPTION
add more informative error message when unsorted integer array is used to index netCDF4 variable on disk.

Closes #593