### PR TITLE
Fix colormap for facet grid plots

### DIFF
--- a/xray/plot/facetgrid.py
+++ b/xray/plot/facetgrid.py
@@ -171,6 +171,7 @@ class FacetGrid(object):
         self._col_wrap = col_wrap
         self._x_var = None
         self._y_var = None
+        self._mappables = []
 
         self.set_titles()
 
@@ -210,9 +211,10 @@ class FacetGrid(object):
                        }
 
         # Allow kwargs to override these defaults
-        for param in kwargs:
+        # Remove cmap_kwargs from kwargs for now, we will add them back later
+        for param in list(kwargs):
             if param in cmap_kwargs:
-                cmap_kwargs[param] = kwargs[param]
+                cmap_kwargs[param] = kwargs.pop(param)
 
         # colormap inference has to happen here since all the data in
         # self.data is required to make the right choice
@@ -239,7 +241,7 @@ class FacetGrid(object):
             # None is the sentinel value
             if d is not None:
                 subset = self.data.loc[d]
-                mappable = func(subset, x, y, ax=ax, **defaults)
+                self._mappables.append(func(subset, x, y, ax=ax, **defaults))
 
         # Left side labels
         for ax in self.axes[:, 0]:
@@ -258,7 +260,7 @@ class FacetGrid(object):
 
         # colorbar
         if kwargs.get('add_colorbar', True):
-            cbar = self.fig.colorbar(mappable,
+            cbar = self.fig.colorbar(self._mappables[-1],
                                      ax=list(self.axes.flat),
                                      extend=cmap_params['extend'])
 

--- a/xray/test/test_plot.py
+++ b/xray/test/test_plot.py
@@ -1,4 +1,3 @@
-import sys
 import inspect
 
 import numpy as np
@@ -548,6 +547,16 @@ class Common2dMixin:
         self.assertArrayEqual(g.axes.shape, [3, 2])
         for ax in g.axes.flat:
             self.assertTrue(ax.has_data())
+
+    def test_facetgrid_cmap(self):
+        # Regression test for GH592
+        data = (np.random.random(size=(20, 25, 12)) + np.linspace(-3, 3, 12))
+        d = DataArray(data, dims=['x', 'y', 'time'])
+        fg = d.plot.pcolormesh(col='time')
+        # check that all color limits are the same
+        self.assertTrue(len(set(m.get_clim() for m in fg._mappables)) == 1)
+        # check that all colormaps are the same
+        self.assertTrue(len(set(m.get_cmap().name for m in fg._mappables)) == 1)
 
 
 class TestContourf(Common2dMixin, PlotTestCase):


### PR DESCRIPTION
Fixes #592

Added test to check that all subplots in facet grid have same data range and colormap.

This fixes two issues present in the existing code: 

1) colormap was being selected for each subplot
2) range was being selected for each subplot and colorbar was the result of only the last subplot

Some sample code: 
```Python
data = (np.random.random(size=(20, 25, 12)) + np.linspace(-3, 3, 12)) # range is ~ -3 to 4
da = xray.DataArray(data, dims=['x', 'y', 'time'], name='data')
fg = da.plot.pcolormesh(col='time', col_wrap=4)
```
previously yielded this plot:
![broken](https://cloud.githubusercontent.com/assets/2443309/10212715/f752a92e-67b7-11e5-8477-f5fc877fe716.png)

and now yields this plot:
![fixed](https://cloud.githubusercontent.com/assets/2443309/10212716/000fe1f8-67b8-11e5-8265-7ce2a89f8fa4.png)


