### PR TITLE
Add subplot_kws arg to plotting interfaces

### DIFF
--- a/doc/api.rst
+++ b/doc/api.rst
@@ -416,4 +416,3 @@ Plotting
    plot.line
    plot.pcolormesh
    plot.FacetGrid
-

--- a/xray/plot/facetgrid.py
+++ b/xray/plot/facetgrid.py
@@ -69,7 +69,7 @@ class FacetGrid(object):
     """
 
     def __init__(self, data, col=None, row=None, col_wrap=None,
-                 aspect=1, size=3):
+                 aspect=1, size=3, subplot_kws=None):
         """
         Parameters
         ----------
@@ -85,6 +85,8 @@ class FacetGrid(object):
             width of each facet in inches
         size : scalar, optional
             Height (in inches) of each facet. See also: ``aspect``
+        subplot_kws : dict, optional
+            Dictionary of keyword arguments for matplotlib subplots
 
         """
 
@@ -127,14 +129,17 @@ class FacetGrid(object):
                 ncol = col_wrap
             nrow = int(np.ceil(nfacet / ncol))
 
+        # Set the subplot kwargs
+        subplot_kws = {} if subplot_kws is None else subplot_kws
+
         # Calculate the base figure size with extra horizontal space for a
         # colorbar
         cbar_space = 1
         figsize = (ncol * size * aspect + cbar_space, nrow * size)
 
         fig, axes = plt.subplots(nrow, ncol,
-                                 sharex=True, sharey=True,
-                                 squeeze=False, figsize=figsize)
+                                 sharex=True, sharey=True, squeeze=False,
+                                 figsize=figsize, subplot_kw=subplot_kws)
 
         # Set up the lists of names for the row and column facet variables
         col_names = list(data[col].values) if col else []

--- a/xray/plot/plot.py
+++ b/xray/plot/plot.py
@@ -81,7 +81,7 @@ def _infer_xy_labels(plotfunc, darray, x, y):
 
 
 def _easy_facetgrid(darray, plotfunc, x, y, row=None, col=None, col_wrap=None,
-                    aspect=1, size=3, **kwargs):
+                    aspect=1, size=3, subplot_kws=None, **kwargs):
     """
     Convenience method to call xray.plot.FacetGrid from 2d plotting methods
 
@@ -92,12 +92,12 @@ def _easy_facetgrid(darray, plotfunc, x, y, row=None, col=None, col_wrap=None,
         raise ValueError("Can't use axes when making faceted plots.")
 
     g = FacetGrid(data=darray, col=col, row=row, col_wrap=col_wrap,
-                  aspect=aspect, size=size)
+                  aspect=aspect, size=size, subplot_kws=subplot_kws)
     return g.map_dataarray(plotfunc, x, y, **kwargs)
 
 
 def plot(darray, row=None, col=None, col_wrap=None, ax=None, rtol=0.01,
-         **kwargs):
+         subplot_kws=None, **kwargs):
     """
     Default plot of DataArray using matplotlib / pylab.
 
@@ -127,6 +127,9 @@ def plot(darray, row=None, col=None, col_wrap=None, ax=None, rtol=0.01,
     rtol : number, optional
         Relative tolerance used to determine if the indexes
         are uniformly spaced. Usually a small positive number.
+    subplot_kws : dict, optional
+        Dictionary of keyword arguments for matplotlib subplots. Only applies
+        to FacetGrid plotting.
     **kwargs : optional
         Additional keyword arguments to matplotlib
 
@@ -151,6 +154,7 @@ def plot(darray, row=None, col=None, col_wrap=None, ax=None, rtol=0.01,
         kwargs['row'] = row
         kwargs['col'] = col
         kwargs['col_wrap'] = col_wrap
+        kwargs['subplot_kws'] = subplot_kws
 
         indexes = (darray.indexes[dim].values for dim in plot_dims)
         uniform = all(is_uniform_spaced(i, rtol=rtol) for i in indexes)
@@ -354,6 +358,9 @@ def _plot2d(plotfunc):
         provided, extend is inferred from vmin, vmax and the data limits.
     levels : int or list-like object, optional
         Split the colormap (cmap) into discrete color intervals.
+    subplot_kws : dict, optional
+        Dictionary of keyword arguments for matplotlib subplots. Only applies
+        to FacetGrid plotting.
     **kwargs : optional
         Additional arguments to wrapped matplotlib function
 
@@ -372,7 +379,7 @@ def _plot2d(plotfunc):
                     col_wrap=None, xincrease=None, yincrease=None,
                     add_colorbar=True, add_labels=True, vmin=None, vmax=None,
                     cmap=None, center=None, robust=False, extend=None,
-                    levels=None, colors=None, **kwargs):
+                    levels=None, colors=None, subplot_kws=None, **kwargs):
         # All 2d plots in xray share this function signature.
         # Method signature below should be consistent.
 
@@ -476,7 +483,7 @@ def _plot2d(plotfunc):
                    col=None, col_wrap=None, xincrease=None, yincrease=None,
                    add_colorbar=True, add_labels=True, vmin=None, vmax=None,
                    cmap=None, colors=None, center=None, robust=False,
-                   extend=None, levels=None, **kwargs):
+                   extend=None, levels=None, subplot_kws=None, **kwargs):
         """
         The method should have the same signature as the function.
 

--- a/xray/test/test_plot.py
+++ b/xray/test/test_plot.py
@@ -136,6 +136,15 @@ class TestPlot(PlotTestCase):
         with self.assertRaisesRegexp(ValueError, '[Ff]acet'):
             d[0].plot(x='x', y='y', col='z', ax=plt.gca())
 
+    def test_subplot_kws(self):
+        a = easy_array((10, 15, 4))
+        d = DataArray(a, dims=['y', 'x', 'z'])
+        d.coords['z'] = list('abcd')
+        g = d.plot(x='x', y='y', col='z', col_wrap=2, cmap='cool',
+                   subplot_kws=dict(axisbg='r'))
+        for ax in g.axes.flat:
+            self.assertEqual(ax.get_axis_bgcolor(), 'r')
+
     def test_convenient_facetgrid_4d(self):
         a = easy_array((10, 15, 2, 3))
         d = DataArray(a, dims=['y', 'x', 'columns', 'rows'])


### PR DESCRIPTION
This argument is only used in the FacetGrid class and allows users to pass arguments to subplot constructor.

The api change is a pretty simple and just accepts a single new argument (`subplot_kws`).  I think we need to think about how to tweak the subplots a bit more in terms of aspect.

Here's some example code that produces the plot below:

```Python
import xray
import cartopy.crs as ccrs

ds = xray.open_dataset('xray-data/ncep_temperature_north-america_2013-14.nc')
ds.lon -= 360 
lon0 = ds.lon.values.mean()

dss = ds.groupby('time.season').mean('time')

g = dss.air.plot.pcolormesh(col='season', col_wrap=2, transform=ccrs.PlateCarree(),
                            subplot_kws=dict(projection=ccrs.PlateCarree(lon0)))

for ax in g.axes.flat:
    ax.coastlines()
    ax.gridlines()
    ax.set_extent((-161.25, -28.75, 20, 40))
```

![projection1](https://cloud.githubusercontent.com/assets/2443309/10259220/a1f694a4-691a-11e5-805c-2fbbafcab773.png)

Obviously there are some issues with the grid lines too but that may end up getting fixed by a more flexible aspect.

cc @clarkfitzg

closes #603

xref: https://github.com/mwaskom/seaborn/pull/320