### PR TITLE
Ensure xplt.FacetGrid works on Dataset objects

### DIFF
--- a/doc/plotting.rst
+++ b/doc/plotting.rst
@@ -403,8 +403,9 @@ attributes, both 2d Numpy object arrays.
 
     g.name_dicts
 
-It's possible to select the :py:class:`xray.DataArray` corresponding to the FacetGrid
-through the ``name_dicts``.
+It's possible to select the :py:class:`xray.DataArray` or
+:py:class:`xray.Dataset` corresponding to the FacetGrid through the
+``name_dicts``.
 
 .. ipython:: python
 
@@ -429,6 +430,8 @@ they have been plotted.
     @savefig plot_facet_iterator.png height=12in
     plt.show()
 
+TODO: add an example of using the ``map`` method to plot dataset variables
+(e.g., with ``plt.quiver``).
 
 Maps
 ----

--- a/xray/plot/facetgrid.py
+++ b/xray/plot/facetgrid.py
@@ -176,9 +176,16 @@ class FacetGrid(object):
         self._col_wrap = col_wrap
         self._x_var = None
         self._y_var = None
+        self._cmap_extend = None
         self._mappables = []
 
-        self.set_titles()
+    @property
+    def _left_axes(self):
+        return self.axes[:, 0]
+
+    @property
+    def _bottom_axes(self):
+        return self.axes[-1, :]
 
     def map_dataarray(self, func, x, y, **kwargs):
         """
@@ -250,40 +257,70 @@ class FacetGrid(object):
             # None is the sentinel value
             if d is not None:
                 subset = self.data.loc[d]
-                self._mappables.append(func(subset, x, y, ax=ax, **defaults))
+                mappable = func(subset, x, y, ax=ax, **defaults)
+                self._mappables.append(mappable)
 
-        # Left side labels
-        for ax in self.axes[:, 0]:
-            ax.set_ylabel(y)
-
-        # Bottom labels
-        for ax in self.axes[-1, :]:
-            ax.set_xlabel(x)
-
-        self.fig.tight_layout()
-
-        if self._single_group:
-            for d, ax in zip(self.name_dicts.flat, self.axes.flat):
-                if d is None:
-                    ax.set_visible(False)
+        self._cmap_extend = defaults.get('extend')
+        self._finalize_grid(x, y)
 
         # colorbar
         if kwargs.get('add_colorbar', True):
-            cbar = self.fig.colorbar(self._mappables[-1],
-                                     ax=list(self.axes.flat),
-                                     extend=cmap_params['extend'])
-
-            if self.data.name:
-                cbar.set_label(self.data.name, rotation=90,
-                               verticalalignment='bottom')
-
-        self._x_var = x
-        self._y_var = y
+            self.add_colorbar()
 
         return self
 
+    def _finalize_grid(self, *axlabels):
+        """Finalize the annotations and layout."""
+        self.set_axis_labels(*axlabels)
+        self.set_titles()
+        self.fig.tight_layout()
+
+        for ax, namedict in zip(self.axes.flat, self.name_dicts.flat):
+            if namedict is None:
+                ax.set_visible(False)
+
+    def add_colorbar(self, **kwargs):
+        """Draw a colorbar
+        """
+        kwargs = kwargs.copy()
+        if self._cmap_extend is not None:
+            kwargs.setdefault('extend', self._cmap_extend)
+        cbar = self.fig.colorbar(self._mappables[-1],
+                                 ax=list(self.axes.flat),
+                                 **kwargs)
+        if getattr(self.data, 'name', False):
+            cbar.set_label(self.data.name, rotation=90,
+                           verticalalignment='bottom')
+        return self
+
+    def set_axis_labels(self, x_var=None, y_var=None):
+        """Set axis labels on the left column and bottom row of the grid."""
+        if x_var is not None:
+            self._x_var = x_var
+            self.set_xlabels(x_var)
+        if y_var is not None:
+            self._y_var = y_var
+            self.set_ylabels(y_var)
+        return self
+
+    def set_xlabels(self, label=None, **kwargs):
+        """Label the x axis on the bottom row of the grid."""
+        if label is None:
+            label = self._x_var
+        for ax in self._bottom_axes:
+            ax.set_xlabel(label, **kwargs)
+        return self
+
+    def set_ylabels(self, label=None, **kwargs):
+        """Label the y axis on the left column of the grid."""
+        if label is None:
+            label = self._y_var
+        for ax in self._left_axes:
+            ax.set_ylabel(label, **kwargs)
+        return self
+
     def set_titles(self, template="{coord} = {value}", maxchar=30,
-                   fontsize=_FONTSIZE, **kwargs):
+                   **kwargs):
         """
         Draw titles either above each facet or on the grid margins.
 
@@ -293,8 +330,6 @@ class FacetGrid(object):
             Template for plot titles containing {coord} and {value}
         maxchar : int
             Truncate titles at maxchar
-        fontsize : string or int
-            Passed to matplotlib.text
         kwargs : keyword args
             additional arguments to matplotlib.text
 
@@ -303,8 +338,9 @@ class FacetGrid(object):
         self: FacetGrid object
 
         """
+        import matplotlib as mpl
 
-        kwargs['fontsize'] = fontsize
+        kwargs["size"] = kwargs.pop("size", mpl.rcParams["axes.labelsize"])
 
         nicetitle = functools.partial(_nicetitle, maxchar=maxchar,
                                       template=template)
@@ -394,6 +430,10 @@ class FacetGrid(object):
                 data = self.data.loc[namedict]
                 plt.sca(ax)
                 innerargs = [data[a].values for a in args]
-                func(*innerargs, **kwargs)
+                # TODO: is it possible to verify that an artist is mappable?
+                mappable = func(*innerargs, **kwargs)
+                self._mappables.append(mappable)
+
+        self._finalize_grid(*args[:2])
 
         return self

--- a/xray/plot/plot.py
+++ b/xray/plot/plot.py
@@ -343,10 +343,6 @@ def _plot2d(plotfunc):
             allargs = locals().copy()
             allargs.update(allargs.pop('kwargs'))
 
-            # Allows use of better FacetGrid defaults
-            assert allargs.pop('add_labels')
-            assert allargs.pop('add_colorbar')
-
             # Need the decorated plotting function
             allargs['plotfunc'] = globals()[plotfunc.__name__]
 

--- a/xray/plot/plot.py
+++ b/xray/plot/plot.py
@@ -408,7 +408,7 @@ def _plot2d(plotfunc):
             kwargs['levels'] = cmap_params['levels']
 
         # This allows the user to pass in a custom norm coming via kwargs
-        kwargs.setdefault('norm', cmap_params['cnorm'])
+        kwargs.setdefault('norm', cmap_params['norm'])
 
         ax, primitive = plotfunc(xval, yval, zval, ax=ax,
                                  cmap=cmap_params['cmap'],

--- a/xray/plot/utils.py
+++ b/xray/plot/utils.py
@@ -176,7 +176,7 @@ def _determine_cmap_params(plot_data, vmin=None, vmax=None, cmap=None,
         cmap, cnorm = _build_discrete_cmap(cmap, levels, extend, filled)
 
     return dict(vmin=vmin, vmax=vmax, cmap=cmap, extend=extend,
-                levels=levels, cnorm=cnorm)
+                levels=levels, norm=cnorm)
 
 
 def _infer_xy_labels(darray, x, y):

--- a/xray/test/test_plot.py
+++ b/xray/test/test_plot.py
@@ -32,7 +32,8 @@ def text_in_fig():
     return set(alltxt)
 
 
-def find_colorbars():
+def find_possible_colorbars():
+    # nb. this function also matches meshes from pcolormesh
     return plt.gcf().findobj(mpl.collections.QuadMesh)
 
 
@@ -794,7 +795,7 @@ class TestFacetGrid(PlotTestCase):
             clim = np.array(image.get_clim())
             self.assertTrue(np.allclose(expected, clim))
 
-        self.assertEqual(1, len(find_colorbars()))
+        self.assertEqual(1, len(find_possible_colorbars()))
 
     def test_empty_cell(self):
         g = xplt.FacetGrid(self.darray, col='z', col_wrap=2)
@@ -899,11 +900,11 @@ class TestFacetGrid(PlotTestCase):
 
         # colorbar can't be inferred automatically
         self.assertNotIn('foo', alltxt)
-        self.assertEqual(0, len(find_colorbars()))
+        self.assertEqual(0, len(find_possible_colorbars()))
 
         g.add_colorbar(label='colors!')
         self.assertIn('colors!', text_in_fig())
-        self.assertEqual(1, len(find_colorbars()))
+        self.assertEqual(1, len(find_possible_colorbars()))
 
     def test_set_axis_labels(self):
         g = self.g.map_dataarray(xplt.contourf, 'x', 'y')
@@ -911,6 +912,19 @@ class TestFacetGrid(PlotTestCase):
         alltxt = text_in_fig()
         for label in ['longitude', 'latitude']:
             self.assertIn(label, alltxt)
+
+    def test_facetgrid_colorbar(self):
+        a = easy_array((10, 15, 4))
+        d = DataArray(a, dims=['y', 'x', 'z'], name='foo')
+
+        d.plot.imshow(x='x', y='y', col='z')
+        self.assertEqual(1, len(find_possible_colorbars()))
+
+        d.plot.imshow(x='x', y='y', col='z', add_colorbar=True)
+        self.assertEqual(1, len(find_possible_colorbars()))
+
+        d.plot.imshow(x='x', y='y', col='z', add_colorbar=False)
+        self.assertEqual(0, len(find_possible_colorbars()))
 
 
 class TestFacetGrid4d(PlotTestCase):

--- a/xray/test/test_plot.py
+++ b/xray/test/test_plot.py
@@ -270,7 +270,7 @@ class TestDetermineCmapParams(TestCase):
         self.assertEqual(cmap_params['cmap'].name, 'viridis')
         self.assertEqual(cmap_params['extend'], 'both')
         self.assertIsNone(cmap_params['levels'])
-        self.assertIsNone(cmap_params['cnorm'])
+        self.assertIsNone(cmap_params['norm'])
 
     def test_center(self):
         cmap_params = _determine_cmap_params(self.data, center=0.5)
@@ -278,7 +278,7 @@ class TestDetermineCmapParams(TestCase):
         self.assertEqual(cmap_params['cmap'], 'RdBu_r')
         self.assertEqual(cmap_params['extend'], 'neither')
         self.assertIsNone(cmap_params['levels'])
-        self.assertIsNone(cmap_params['cnorm'])
+        self.assertIsNone(cmap_params['norm'])
 
     def test_integer_levels(self):
         data = self.data + 1
@@ -289,7 +289,7 @@ class TestDetermineCmapParams(TestCase):
         self.assertEqual(cmap_params['cmap'].name, 'Blues')
         self.assertEqual(cmap_params['extend'], 'neither')
         self.assertEqual(cmap_params['cmap'].N, 5)
-        self.assertEqual(cmap_params['cnorm'].N, 6)
+        self.assertEqual(cmap_params['norm'].N, 6)
 
         cmap_params = _determine_cmap_params(data, levels=5,
                                              vmin=0.5, vmax=1.5)
@@ -306,7 +306,7 @@ class TestDetermineCmapParams(TestCase):
         self.assertEqual(cmap_params['vmin'], 0)
         self.assertEqual(cmap_params['vmax'], 5)
         self.assertEqual(cmap_params['cmap'].N, 5)
-        self.assertEqual(cmap_params['cnorm'].N, 6)
+        self.assertEqual(cmap_params['norm'].N, 6)
 
         for wrap_levels in [list, np.array, pd.Index, DataArray]:
             cmap_params = _determine_cmap_params(


### PR DESCRIPTION
This, along with the ``.map`` method, provides a much more generally flexible API for making plots.

It still needs some examples for the docs. Here's something simple with synthetic data:

    ds = xray.Dataset({'x': np.linspace(0, 10),
                       'y': [1, 2, 3],
                       'foo': ('x', np.random.randn(50)),
                       'bar': ('x', np.random.rand(50))})
    ds *= ds.y
    (xplt.FacetGrid(ds, col='y')
     .map(plt.plot, 'x', 'foo')
     .map(plt.scatter, 'x', 'bar', color='green'))

![image](https://cloud.githubusercontent.com/assets/1217238/10361287/f8306418-6d5b-11e5-87bd-845959f329d0.png)
