### PR TITLE
numpy 1.10 compat fixes

### DIFF
--- a/doc/whats-new.rst
+++ b/doc/whats-new.rst
@@ -42,7 +42,7 @@ Enhancements
 Bug fixes
 ~~~~~~~~~
 
-- Forwards compatibility with the next release of changes (v0.17.0).
+- Forwards compatibility with the next pandas release of changes (v0.17.0).
   We were using some internal pandas routines for datetime conversion, which
   unfortunately have now changed upstream (:issue:`569`).
 - Aggregation functions now correctly skip ``NaN`` for data for ``complex128``
@@ -58,6 +58,7 @@ Bug fixes
 - It is now possible to assign to the ``.data`` attribute of DataArray objects.
 - ``coordinates`` attribute is now kept in the encoding dictionary after
   decoding (:issue:`610`).
+- Compatibility with numpy 1.10 (:issue:`617`).
 
 v0.6.0 (21 August 2015)
 -----------------------

--- a/xray/core/npcompat.py
+++ b/xray/core/npcompat.py
@@ -5,7 +5,7 @@ See the NumPy license in the licenses directory.
 import numpy as np
 
 try:
-    from numpy import broadcast_to, stack
+    from numpy import broadcast_to, stack, nanprod
 except ImportError:  # pragma: no cover
     # these functions should arrive in numpy v1.10
 
@@ -124,18 +124,20 @@ except ImportError:  # pragma: no cover
         arrays = [np.asanyarray(arr) for arr in arrays]
         if not arrays:
             raise ValueError('need at least one array to stack')
+
+        shapes = set(arr.shape for arr in arrays)
+        if len(shapes) != 1:
+            raise ValueError('all input arrays must have the same shape')
+
         result_ndim = arrays[0].ndim + 1
         if not -result_ndim <= axis < result_ndim:
-            raise IndexError('axis %r out of bounds [-%r, %r)'
-                             % (axis, result_ndim, result_ndim))
+            msg = 'axis {0} out of bounds [-{1}, {1})'.format(axis, result_ndim)
+            raise IndexError(msg)
         if axis < 0:
             axis += result_ndim
+
         sl = (slice(None),) * axis + (np.newaxis,)
-        try:
-            expanded_arrays = [arr[sl] for arr in arrays]
-        except IndexError:
-            msg = 'all the input arrays must have same number of dimensions'
-            raise ValueError(msg)
+        expanded_arrays = [arr[sl] for arr in arrays]
         return np.concatenate(expanded_arrays, axis=axis)
 
 

--- a/xray/core/nputils.py
+++ b/xray/core/nputils.py
@@ -1,5 +1,6 @@
 import numpy as np
 import pandas as pd
+import warnings
 
 from .pycompat import builtins, reduce
 
@@ -68,8 +69,12 @@ def _ensure_bool_is_ndarray(result, *args):
 
 
 def array_eq(self, other):
-    return _ensure_bool_is_ndarray(self == other, self, other)
+    with warnings.catch_warnings():
+        warnings.filterwarnings('ignore', r'elementwise comparison failed')
+        return _ensure_bool_is_ndarray(self == other, self, other)
 
 
 def array_ne(self, other):
-    return _ensure_bool_is_ndarray(self != other, self, other)
+    with warnings.catch_warnings():
+        warnings.filterwarnings('ignore', r'elementwise comparison failed')
+        return _ensure_bool_is_ndarray(self != other, self, other)

--- a/xray/test/__init__.py
+++ b/xray/test/__init__.py
@@ -150,6 +150,9 @@ class TestCase(unittest.TestCase):
     # TODO: write a generic "assertEqual" that uses the equals method, or just
     # switch to py.test and add an appropriate hook.
 
+    def assertEqual(self, a1, a2):
+        assert a1 == a2 or (a1 != a1 and a2 != a2)
+
     def assertDatasetEqual(self, d1, d2):
         # this method is functionally equivalent to `assert d1 == d2`, but it
         # checks each aspect of equality separately for easier debugging

--- a/xray/test/test_dataarray.py
+++ b/xray/test/test_dataarray.py
@@ -1235,8 +1235,8 @@ class TestDataArray(TestCase):
         # regression test for #264
         x1 = np.arange(30)
         x2 = np.arange(5, 35)
-        a = DataArray(np.random.random((30,)).astype('f32'), {'x': x1})
-        b = DataArray(np.random.random((30,)).astype('f32'), {'x': x2})
+        a = DataArray(np.random.random((30,)).astype(np.float32), {'x': x1})
+        b = DataArray(np.random.random((30,)).astype(np.float32), {'x': x2})
         c, d = align(a, b, join='outer')
         self.assertEqual(c.dtype, np.float32)
 

--- a/xray/test/test_variable.py
+++ b/xray/test/test_variable.py
@@ -110,6 +110,8 @@ class VariableSubclassTestCases(object):
     def test_index_0d_not_a_time(self):
         d = np.datetime64('NaT')
         x = self.cls(['x'], [d])
+        # Wasn't able to figure out why this was failing.
+        # AssertionError: numpy.datetime64('NaT') != numpy.datetime64('NaT')
         self.assertIndexedLikeNDArray(x, d, None)
 
     def test_index_0d_object(self):
@@ -332,7 +334,7 @@ class VariableSubclassTestCases(object):
         self.assertVariableIdentical(v, Variable.concat([v[:1], v[1:]], 'time'))
         # test dimension order
         self.assertVariableIdentical(v, Variable.concat([v[:, :5], v[:, 5:]], 'x'))
-        with self.assertRaisesRegexp(ValueError, 'same number of dimensions'):
+        with self.assertRaisesRegexp(ValueError, 'all input arrays must have'):
             Variable.concat([v[:, 0], v[:, 1:]], 'x')
 
     def test_concat_attrs(self):

--- a/xray/test/test_variable.py
+++ b/xray/test/test_variable.py
@@ -108,10 +108,8 @@ class VariableSubclassTestCases(object):
         self.assertIndexedLikeNDArray(x, np.timedelta64(td), 'timedelta64[ns]')
 
     def test_index_0d_not_a_time(self):
-        d = np.datetime64('NaT')
+        d = np.datetime64('NaT', 'ns')
         x = self.cls(['x'], [d])
-        # Wasn't able to figure out why this was failing.
-        # AssertionError: numpy.datetime64('NaT') != numpy.datetime64('NaT')
         self.assertIndexedLikeNDArray(x, d, None)
 
     def test_index_0d_object(self):


### PR DESCRIPTION
fixes #617 

@shoyer - can you take a look at `test_index_0d_not_a_time` and see if you can figure out why that test is failing?  I couldn't sort it out.

Also, we're now getting a ton of these warnings: 

```FutureWarning: numpy equal will not check object identity in the future. The comparison did not return the same result as suggested by the identity (`is`)) and will change.```

I thought about trying to suppress the ones that come directly from xray but that seems tricky to do safely. matplotlib and numpy itself are raising the same warnings.  err...