### PR TITLE
ENH: add tolerance argument to .sel and .reindex

### DIFF
--- a/ci/requirements-py26.yml
+++ b/ci/requirements-py26.yml
@@ -13,5 +13,6 @@ dependencies:
   - unittest2
   - pip:
     - coveralls
+    - cyordereddict
     - dask
     - h5netcdf

--- a/doc/indexing.rst
+++ b/doc/indexing.rst
@@ -214,7 +214,7 @@ Nearest neighbor lookups
 
 The label based selection methods :py:meth:`~xray.Dataset.sel`,
 :py:meth:`~xray.Dataset.reindex` and :py:meth:`~xray.Dataset.reindex_like` all
-support a ``method`` keyword argument. The method parameter allows for
+support ``method`` and ``tolerance`` keyword argument. The method parameter allows for
 enabling nearest neighbor (inexact) lookups by use of the methods ``'pad'``,
 ``'backfill'`` or ``'nearest'``:
 
@@ -225,8 +225,14 @@ enabling nearest neighbor (inexact) lookups by use of the methods ``'pad'``,
     data.sel(x=0.1, method='backfill')
     data.reindex(x=[0.5, 1, 1.5, 2, 2.5], method='pad')
 
+Tolerance limits the maximum distance for valid matches with an inexact lookup:
+
+.. ipython:: python
+
+    data.reindex(x=[1.1, 1.5], method='nearest', tolerance=0.2)
+
 Using ``method='nearest'`` or a scalar argument with ``.sel()`` requires pandas
-version 0.16 or newer.
+version 0.16 or newer. Using ``tolerance`` requries pandas version 0.17 or newer.
 
 The method parameter is not yet supported if any of the arguments
 to ``.sel()`` is a ``slice`` object:

--- a/doc/whats-new.rst
+++ b/doc/whats-new.rst
@@ -12,7 +12,11 @@ What's New
 v0.6.1
 ------
 
-The minimum required version of dask for use with xray is now version 0.6.
+This pull request contains a number of bug and compatibility fixes, as well
+as enhancements to indexing, plotting and writing files to disk.
+
+Note that the minimum required version of dask for use with xray is now
+version 0.6.
 
 API Changes
 ~~~~~~~~~~~
@@ -26,6 +30,28 @@ API Changes
 Enhancements
 ~~~~~~~~~~~~
 
+- :py:meth:`~xray.Dataset.sel` and :py:meth:`~xray.Dataset.reindex` now support
+  the ``tolerance`` argument for controlling nearest-neighbor selection
+  (:issue:`629`)::
+
+  .. ipython::
+    :verbatim:
+
+    In [5]: array = xray.DataArray([1, 2, 3], dims='x')
+
+    In [6]: array.reindex(x=[0.9, 1.5], method='nearest', tolerance=0.2)
+    Out[6]:
+    <xray.DataArray (x: 2)>
+    array([  2.,  nan])
+    Coordinates:
+      * x        (x) float64 0.9 1.5
+
+  This feature requires pandas v0.17 or newer.
+- Faceted plotting through :py:class:`~xray.plot.FacetGrid` and the
+  :py:meth:`~xray.plot.plot` method.
+- New ``encoding`` argument in :py:meth:`~xray.Dataset.to_netcdf` for writing
+  netCDF files with compression, as described in the new documentation
+  section on :ref:`io.netcdf.writing_encoded`.
 - Add :py:attr:`~xray.Dataset.real` and :py:attr:`~xray.Dataset.imag`
   attributes to Dataset and DataArray (:issue:`553`).
 - More informative error message with :py:meth:`~xray.Dataset.from_dataframe`
@@ -33,17 +59,12 @@ Enhancements
 - xray now uses deterministic names for dask arrays it creates or opens from
   disk. This allows xray users to take advantage of dask's nascent support for
   caching intermediate computation results. See :issue:`555` for an example.
-- Faceted plotting through :py:class:`~xray.plot.FacetGrid` and the
-  :py:meth:`~xray.plot.plot` method.
-- New ``encoding`` argument in :py:meth:`~xray.Dataset.to_netcdf` for writing
-  netCDF files with compression, as described in the new documentation
-  section on :ref:`io.netcdf.writing_encoded`.
 
 Bug fixes
 ~~~~~~~~~
 
-- Forwards compatibility with the next pandas release of changes (v0.17.0).
-  We were using some internal pandas routines for datetime conversion, which
+- Forwards compatibility with the latest pandas release (v0.17.0). We were
+  using some internal pandas routines for datetime conversion, which
   unfortunately have now changed upstream (:issue:`569`).
 - Aggregation functions now correctly skip ``NaN`` for data for ``complex128``
   dtype (:issue:`554`).

--- a/xray/core/alignment.py
+++ b/xray/core/alignment.py
@@ -1,5 +1,6 @@
 import functools
 import operator
+import pandas as pd
 from collections import defaultdict
 
 import numpy as np
@@ -146,6 +147,9 @@ def reindex_variables(variables, indexes, indexers, method=None,
     # for compat with older versions of pandas that don't support tolerance
     get_indexer_kwargs = {}
     if tolerance is not None:
+        if pd.__version__ < '0.17':
+            raise NotImplementedError(
+                'the tolerance argument requires pandas v0.17 or newer')
         get_indexer_kwargs['tolerance'] = tolerance
 
     for name, index in iteritems(indexes):

--- a/xray/core/dataarray.py
+++ b/xray/core/dataarray.py
@@ -539,7 +539,7 @@ class DataArray(AbstractArray, BaseDataObject):
         ds = self._dataset.isel(**indexers)
         return self._with_replaced_dataset(ds)
 
-    def sel(self, method=None, **indexers):
+    def sel(self, method=None, tolerance=None, **indexers):
         """Return a new DataArray whose dataset is given by selecting
         index labels along the specified dimension(s).
 
@@ -548,8 +548,8 @@ class DataArray(AbstractArray, BaseDataObject):
         Dataset.sel
         DataArray.isel
         """
-        return self.isel(**indexing.remap_label_indexers(self, indexers,
-                                                         method=method))
+        return self.isel(**indexing.remap_label_indexers(
+            self, indexers, method=method, tolerance=tolerance))
 
     def isel_points(self, dim='points', **indexers):
         """Return a new DataArray whose dataset is given by pointwise integer
@@ -562,7 +562,8 @@ class DataArray(AbstractArray, BaseDataObject):
         ds = self._dataset.isel_points(dim=dim, **indexers)
         return self._with_replaced_dataset(ds)
 
-    def sel_points(self, dim='points', method=None, **indexers):
+    def sel_points(self, dim='points', method=None, tolerance=None,
+                   **indexers):
         """Return a new DataArray whose dataset is given by pointwise selection
         of index labels along the specified dimension(s).
 
@@ -570,10 +571,11 @@ class DataArray(AbstractArray, BaseDataObject):
         --------
         Dataset.sel_points
         """
-        ds = self._dataset.sel_points(dim=dim, method=method, **indexers)
+        ds = self._dataset.sel_points(dim=dim, method=method,
+                                      tolerance=tolerance, **indexers)
         return self._with_replaced_dataset(ds)
 
-    def reindex_like(self, other, method=None, copy=True):
+    def reindex_like(self, other, method=None, tolerance=None, copy=True):
         """Conform this object onto the indexes of another object, filling
         in missing values with NaN.
 
@@ -594,6 +596,11 @@ class DataArray(AbstractArray, BaseDataObject):
             * pad / ffill: propgate last valid index value forward
             * backfill / bfill: propagate next valid index value backward
             * nearest: use nearest valid index value (requires pandas>=0.16)
+        tolerance : optional
+            Maximum distance between original and new labels for inexact
+            matches. The values of the index at the matching locations most
+            satisfy the equation ``abs(index[indexer] - target) <= tolerance``.
+            Requires pandas>=0.17.
         copy : bool, optional
             If `copy=True`, the returned array's dataset contains only copied
             variables. If `copy=False` and no reindexing is required then
@@ -610,9 +617,10 @@ class DataArray(AbstractArray, BaseDataObject):
         DataArray.reindex
         align
         """
-        return self.reindex(method=method, copy=copy, **other.indexes)
+        return self.reindex(method=method, tolerance=tolerance, copy=copy,
+                            **other.indexes)
 
-    def reindex(self, method=None, copy=True, **indexers):
+    def reindex(self, method=None, tolerance=None, copy=True, **indexers):
         """Conform this object onto a new set of indexes, filling in
         missing values with NaN.
 
@@ -630,6 +638,11 @@ class DataArray(AbstractArray, BaseDataObject):
             * pad / ffill: propgate last valid index value forward
             * backfill / bfill: propagate next valid index value backward
             * nearest: use nearest valid index value (requires pandas>=0.16)
+        tolerance : optional
+            Maximum distance between original and new labels for inexact
+            matches. The values of the index at the matching locations most
+            satisfy the equation ``abs(index[indexer] - target) <= tolerance``.
+            Requires pandas>=0.17.
         **indexers : dict
             Dictionary with keys given by dimension names and values given by
             arrays of coordinates tick labels. Any mis-matched coordinate values
@@ -647,7 +660,8 @@ class DataArray(AbstractArray, BaseDataObject):
         DataArray.reindex_like
         align
         """
-        ds = self._dataset.reindex(method=method, copy=copy, **indexers)
+        ds = self._dataset.reindex(method=method, tolerance=tolerance,
+                                   copy=copy, **indexers)
         return self._with_replaced_dataset(ds)
 
     def rename(self, new_name_or_name_dict):

--- a/xray/core/dataset.py
+++ b/xray/core/dataset.py
@@ -1002,7 +1002,7 @@ class Dataset(Mapping, ImplementsDatasetReduce, BaseDataObject):
             variables[name] = var.isel(**var_indexers)
         return self._replace_vars_and_dims(variables)
 
-    def sel(self, method=None, **indexers):
+    def sel(self, method=None, tolerance=None, **indexers):
         """Returns a new dataset with each array indexed by tick labels
         along the specified dimension(s).
 
@@ -1028,6 +1028,11 @@ class Dataset(Mapping, ImplementsDatasetReduce, BaseDataObject):
             * pad / ffill: propgate last valid index value forward
             * backfill / bfill: propagate next valid index value backward
             * nearest: use nearest valid index value
+        tolerance : optional
+            Maximum distance between original and new labels for inexact
+            matches. The values of the index at the matching locations most
+            satisfy the equation ``abs(index[indexer] - target) <= tolerance``.
+            Requires pandas>=0.17.
         **indexers : {dim: indexer, ...}
             Keyword arguments with names matching dimensions and values given
             by scalars, slices or arrays of tick labels.
@@ -1048,8 +1053,8 @@ class Dataset(Mapping, ImplementsDatasetReduce, BaseDataObject):
         Dataset.isel_points
         DataArray.sel
         """
-        return self.isel(**indexing.remap_label_indexers(self, indexers,
-                                                         method=method))
+        return self.isel(**indexing.remap_label_indexers(
+            self, indexers, method=method, tolerance=tolerance))
 
     def isel_points(self, dim='points', **indexers):
         """Returns a new dataset with each array indexed pointwise along the
@@ -1138,7 +1143,8 @@ class Dataset(Mapping, ImplementsDatasetReduce, BaseDataObject):
                         zip(*[v for k, v in indexers])]],
                       dim=dim, coords=coords, data_vars=data_vars)
 
-    def sel_points(self, dim='points', method=None, **indexers):
+    def sel_points(self, dim='points', method=None, tolerance=None,
+                   **indexers):
         """Returns a new dataset with each array indexed pointwise by tick
         labels along the specified dimension(s).
 
@@ -1164,6 +1170,11 @@ class Dataset(Mapping, ImplementsDatasetReduce, BaseDataObject):
             * pad / ffill: propgate last valid index value forward
             * backfill / bfill: propagate next valid index value backward
             * nearest: use nearest valid index value
+        tolerance : optional
+            Maximum distance between original and new labels for inexact
+            matches. The values of the index at the matching locations most
+            satisfy the equation ``abs(index[indexer] - target) <= tolerance``.
+            Requires pandas>=0.17.
         **indexers : {dim: indexer, ...}
             Keyword arguments with names matching dimensions and values given
             by array-like objects. All indexers must be the same length and
@@ -1184,11 +1195,11 @@ class Dataset(Mapping, ImplementsDatasetReduce, BaseDataObject):
         Dataset.isel_points
         DataArray.sel_points
         """
-        pos_indexers = indexing.remap_label_indexers(self, indexers,
-                                                     method=method)
+        pos_indexers = indexing.remap_label_indexers(
+            self, indexers, method=method, tolerance=tolerance)
         return self.isel_points(dim=dim, **pos_indexers)
 
-    def reindex_like(self, other, method=None, copy=True):
+    def reindex_like(self, other, method=None, tolerance=None, copy=True):
         """Conform this object onto the indexes of another object, filling
         in missing values with NaN.
 
@@ -1209,6 +1220,11 @@ class Dataset(Mapping, ImplementsDatasetReduce, BaseDataObject):
             * pad / ffill: propgate last valid index value forward
             * backfill / bfill: propagate next valid index value backward
             * nearest: use nearest valid index value (requires pandas>=0.16)
+        tolerance : optional
+            Maximum distance between original and new labels for inexact
+            matches. The values of the index at the matching locations most
+            satisfy the equation ``abs(index[indexer] - target) <= tolerance``.
+            Requires pandas>=0.17.
         copy : bool, optional
             If `copy=True`, the returned dataset contains only copied
             variables. If `copy=False` and no reindexing is required then
@@ -1225,9 +1241,10 @@ class Dataset(Mapping, ImplementsDatasetReduce, BaseDataObject):
         Dataset.reindex
         align
         """
-        return self.reindex(method=method, copy=copy, **other.indexes)
+        return self.reindex(method=method, copy=copy, tolerance=tolerance,
+                            **other.indexes)
 
-    def reindex(self, indexers=None, method=None, copy=True, **kw_indexers):
+    def reindex(self, indexers=None, method=None, tolerance=None, copy=True, **kw_indexers):
         """Conform this object onto a new set of indexes, filling in
         missing values with NaN.
 
@@ -1246,6 +1263,11 @@ class Dataset(Mapping, ImplementsDatasetReduce, BaseDataObject):
             * pad / ffill: propgate last valid index value forward
             * backfill / bfill: propagate next valid index value backward
             * nearest: use nearest valid index value (requires pandas>=0.16)
+        tolerance : optional
+            Maximum distance between original and new labels for inexact
+            matches. The values of the index at the matching locations most
+            satisfy the equation ``abs(index[indexer] - target) <= tolerance``.
+            Requires pandas>=0.17.
         copy : bool, optional
             If `copy=True`, the returned dataset contains only copied
             variables. If `copy=False` and no reindexing is required then
@@ -1271,7 +1293,7 @@ class Dataset(Mapping, ImplementsDatasetReduce, BaseDataObject):
             return self.copy(deep=True) if copy else self
 
         variables = alignment.reindex_variables(
-            self.variables, self.indexes, indexers, method, copy=copy)
+            self.variables, self.indexes, indexers, method, tolerance, copy=copy)
         return self._replace_vars_and_dims(variables)
 
     def rename(self, name_dict, inplace=False):

--- a/xray/core/indexing.py
+++ b/xray/core/indexing.py
@@ -117,25 +117,24 @@ def _try_get_item(x):
         return x
 
 
-def _get_loc(index, label, method=None):
-    """Backwards compatible wrapper for Index.get_loc, which only added the
-    method argument in pandas 0.16
-    """
-    if method is not None:
-        return index.get_loc(label, method=method)
-    else:
-        return index.get_loc(label)
-
-
-def convert_label_indexer(index, label, index_name='', method=None):
+def convert_label_indexer(index, label, index_name='', method=None,
+                          tolerance=None):
     """Given a pandas.Index (or xray.Coordinate) and labels (e.g., from
     __getitem__) for one dimension, return an indexer suitable for indexing an
     ndarray along that dimension
     """
+    # backwards compatibility for pandas<0.16 (method) or pandas<0.17
+    # (tolerance)
+    kwargs = {}
+    if method is not None:
+        kwargs['method'] = method
+    if tolerance is not None:
+        kwargs['tolerance'] = tolerance
+
     if isinstance(label, slice):
-        if method is not None:
+        if method is not None or tolerance is not None:
             raise NotImplementedError(
-                'cannot yet use the ``method`` argument if any indexers are '
+                'cannot use ``method`` argument if any indexers are '
                 'slice objects')
         indexer = index.slice_indexer(_try_get_item(label.start),
                                       _try_get_item(label.stop),
@@ -149,25 +148,25 @@ def convert_label_indexer(index, label, index_name='', method=None):
     else:
         label = np.asarray(label)
         if label.ndim == 0:
-            indexer = _get_loc(index, np.asscalar(label), method=method)
+            indexer = index.get_loc(np.asscalar(label), **kwargs)
         elif label.dtype.kind == 'b':
             indexer, = np.nonzero(label)
         else:
-            indexer = index.get_indexer(label, method=method)
+            indexer = index.get_indexer(label, **kwargs)
             if np.any(indexer < 0):
                 raise KeyError('not all values found in index %r'
                                % index_name)
     return indexer
 
 
-def remap_label_indexers(data_obj, indexers, method=None):
+def remap_label_indexers(data_obj, indexers, method=None, tolerance=None):
     """Given an xray data object and label based indexers, return a mapping
     of equivalent location based indexers.
     """
     if method is not None and not isinstance(method, str):
         raise TypeError('``method`` must be a string')
     return dict((dim, convert_label_indexer(data_obj[dim].to_index(), label,
-                                            dim, method))
+                                            dim, method, tolerance))
                 for dim, label in iteritems(indexers))
 
 

--- a/xray/core/indexing.py
+++ b/xray/core/indexing.py
@@ -129,6 +129,9 @@ def convert_label_indexer(index, label, index_name='', method=None,
     if method is not None:
         kwargs['method'] = method
     if tolerance is not None:
+        if pd.__version__ < '0.17':
+            raise NotImplementedError(
+                'the tolerance argument requires pandas v0.17 or newer')
         kwargs['tolerance'] = tolerance
 
     if isinstance(label, slice):

--- a/xray/test/test_dataarray.py
+++ b/xray/test/test_dataarray.py
@@ -392,9 +392,10 @@ class TestDataArray(TestCase):
         actual = data.sel(y=['ab', 'ba'], method='pad')
         self.assertDataArrayIdentical(expected, actual)
 
-        expected = data.sel(x=[1, 2])
-        actual = data.sel(x=[0.9, 1.9], method='backfill')
-        self.assertDataArrayIdentical(expected, actual)
+        if pd.__version__ >= '0.17':
+            expected = data.sel(x=[1, 2])
+            actual = data.sel(x=[0.9, 1.9], method='backfill', tolerance=1)
+            self.assertDataArrayIdentical(expected, actual)
 
     def test_isel_points(self):
         shape = (10, 5, 6)
@@ -609,13 +610,15 @@ class TestDataArray(TestCase):
 
     def test_reindex_method(self):
         x = DataArray([10, 20], dims='y')
-        y = [-0.5, 0.5, 1.5]
-        actual = x.reindex(y=y, method='backfill')
-        expected = DataArray([10, 20, np.nan], coords=[('y', y)])
-        self.assertDataArrayIdentical(expected, actual)
+        y = [-0.1, 0.5, 1.1]
+        if pd.__version__ >= '0.17':
+            actual = x.reindex(y=y, method='backfill', tolerance=0.2)
+            expected = DataArray([10, np.nan, np.nan], coords=[('y', y)])
+            self.assertDataArrayIdentical(expected, actual)
 
         alt = Dataset({'y': y})
         actual = x.reindex_like(alt, method='backfill')
+        expected = DataArray([10, 20, np.nan], coords=[('y', y)])
         self.assertDatasetIdentical(expected, actual)
 
     def test_rename(self):

--- a/xray/test/test_dataarray.py
+++ b/xray/test/test_dataarray.py
@@ -396,6 +396,9 @@ class TestDataArray(TestCase):
             expected = data.sel(x=[1, 2])
             actual = data.sel(x=[0.9, 1.9], method='backfill', tolerance=1)
             self.assertDataArrayIdentical(expected, actual)
+        else:
+            with self.assertRaisesRegexp(NotImplementedError, 'tolerance'):
+                data.sel(x=[0.9, 1.9], method='backfill', tolerance=1)
 
     def test_isel_points(self):
         shape = (10, 5, 6)

--- a/xray/test/test_dataset.py
+++ b/xray/test/test_dataset.py
@@ -749,6 +749,10 @@ class TestDataset(TestCase):
                                  method='pad')
         self.assertDatasetIdentical(expected, actual)
 
+        if pd.__version__ >= '0.17':
+            with self.assertRaises(KeyError):
+                data.sel_points(x=[2.5], y=[2.0], method='pad', tolerance=1e-3)
+
     def test_sel_method(self):
         data = create_test_data()
 
@@ -756,6 +760,13 @@ class TestDataset(TestCase):
             expected = data.sel(dim1=1)
             actual = data.sel(dim1=0.95, method='nearest')
             self.assertDatasetIdentical(expected, actual)
+
+        if pd.__version__ >= '0.17':
+            actual = data.sel(dim1=0.95, method='nearest', tolerance=1)
+            self.assertDatasetIdentical(expected, actual)
+
+            with self.assertRaises(KeyError):
+                actual = data.sel(dim1=0.5, method='nearest', tolerance=0)
 
         expected = data.sel(dim2=[1.5])
         actual = data.sel(dim2=[1.45], method='backfill')
@@ -845,6 +856,11 @@ class TestDataset(TestCase):
         actual = ds.reindex(y=y, method='backfill')
         expected = Dataset({'x': ('y', [10, 20, np.nan]), 'y': y})
         self.assertDatasetIdentical(expected, actual)
+
+        if pd.__version__ >= '0.17':
+            actual = ds.reindex(y=y, method='backfill', tolerance=0.1)
+            expected = Dataset({'x': ('y', 3 * [np.nan]), 'y': y})
+            self.assertDatasetIdentical(expected, actual)
 
         actual = ds.reindex(y=y, method='pad')
         expected = Dataset({'x': ('y', [np.nan, 10, 20]), 'y': y})

--- a/xray/test/test_dataset.py
+++ b/xray/test/test_dataset.py
@@ -861,6 +861,9 @@ class TestDataset(TestCase):
             actual = ds.reindex(y=y, method='backfill', tolerance=0.1)
             expected = Dataset({'x': ('y', 3 * [np.nan]), 'y': y})
             self.assertDatasetIdentical(expected, actual)
+        else:
+            with self.assertRaisesRegexp(NotImplementedError, 'tolerance'):
+                ds.reindex(y=y, method='backfill', tolerance=0.1)
 
         actual = ds.reindex(y=y, method='pad')
         expected = Dataset({'x': ('y', [np.nan, 10, 20]), 'y': y})


### PR DESCRIPTION
`.sel` and `.reindex` now support the ``tolerance`` argument for controlling nearest-neighbor selection:

    In [5]: array = xray.DataArray([1, 2, 3], dims='x')

    In [6]: array.reindex(x=[0.9, 1.5], method='nearest', tolerance=0.2)
    Out[6]:
    <xray.DataArray (x: 2)>
    array([  2.,  nan])
    Coordinates:
      * x        (x) float64 0.9 1.5

This feature requires pandas v0.17 or newer.