### PR TITLE
Remove all mutable arguments from functions

### DIFF
--- a/xray/backends/api.py
+++ b/xray/backends/api.py
@@ -312,7 +312,7 @@ WRITEABLE_STORES = {'netcdf4': backends.NetCDF4DataStore,
 
 
 def to_netcdf(dataset, path=None, mode='w', format=None, group=None,
-              engine=None, writer=None, encoding={}):
+              engine=None, writer=None, encoding=None):
     """This function creates an appropriate datastore for writing a dataset to
     disk as a netCDF file
 
@@ -320,6 +320,8 @@ def to_netcdf(dataset, path=None, mode='w', format=None, group=None,
 
     The ``writer`` argument is only for the private use of save_mfdataset.
     """
+    if encoding is None:
+        encoding = {}
     if path is None:
         path = BytesIO()
         if engine is None:

--- a/xray/core/coordinates.py
+++ b/xray/core/coordinates.py
@@ -7,7 +7,9 @@ from . import formatting
 
 
 def _coord_merge_finalize(target, other, target_conflicts, other_conflicts,
-                          promote_dims={}):
+                          promote_dims=None):
+    if promote_dims is None:
+        promote_dims = {}
     for k in target_conflicts:
         del target[k]
     for k, v in iteritems(other):


### PR DESCRIPTION
http://docs.python-guide.org/en/latest/writing/gotchas/#mutable-default-arguments

Not sure if you want this or not. I didn't see any cases where this was being used intentionally to store state between calls.