### PR TITLE
Read only support for PyNIO backend

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,7 @@ matrix:
   - python: 2.7
     env: CONDA_ENV=py27-min
   - python: 2.7
-    env: CONDA_ENV=py27-cdat
+    env: CONDA_ENV=py27-cdat+pynio
   - python: 3.4
     env: CONDA_ENV=py34
   - python: 3.5

--- a/ci/requirements-py27-cdat+pynio.yml
+++ b/ci/requirements-py27-cdat+pynio.yml
@@ -2,7 +2,6 @@ name: test_env
 channels:
   - ajdawson  # cdat
   - dbrown  # pynio
-  - asmeurer  # gcc-4.8.5, needed for pynio
 dependencies:
   - python=2.7
   - cdat-lite

--- a/ci/requirements-py27-cdat+pynio.yml
+++ b/ci/requirements-py27-cdat+pynio.yml
@@ -1,6 +1,8 @@
 name: test_env
 channels:
-  - ajdawson
+  - ajdawson  # cdat
+  - dbrown  # pynio
+  - asmeurer  # gcc-4.8.5, needed for pynio
 dependencies:
   - python=2.7
   - cdat-lite
@@ -8,6 +10,7 @@ dependencies:
   - pytest
   - numpy
   - pandas>=0.15.0
+  - pynio
   - scipy
   - pip:
     - coveralls

--- a/doc/io.rst
+++ b/doc/io.rst
@@ -337,6 +337,21 @@ over the network until we look at particular values:
 
 .. image:: _static/opendap-prism-tmax.png
 
+.. _io.pynio:
+
+Formats supported by PyNIO
+--------------------------
+
+Xray can also read GRIB, HDF4 and other file formats supported by PyNIO_,
+if PyNIO is installed. To use PyNIO to read such files, supply
+``engine='pynio'`` to :py:func:`~xray.open_dataset`.
+
+We recommend installing PyNIO via conda::
+
+    conda install -c dbrown pynio
+
+.. _PyNIO: https://www.pyngl.ucar.edu/Nio.shtml
+
 .. _combining multiple files:
 
 Combining multiple files

--- a/doc/whats-new.rst
+++ b/doc/whats-new.rst
@@ -9,6 +9,18 @@ What's New
     import xray
     np.random.seed(123456)
 
+v0.6.2 (unreleased)
+-------------------
+
+Enhancements
+~~~~~~~~~~~~
+
+- Read-only support for reading files with PyNIO_. Use ``engine='pynio'``
+  with :py:func:`xray.open_dataset`.
+
+_PyNIO: https://www.pyngl.ucar.edu/Nio.shtml
+
+
 v0.6.1 (21 October 2015)
 ------------------------
 

--- a/doc/whats-new.rst
+++ b/doc/whats-new.rst
@@ -15,10 +15,8 @@ v0.6.2 (unreleased)
 Enhancements
 ~~~~~~~~~~~~
 
-- Read-only support for reading files with PyNIO_. Use ``engine='pynio'``
-  with :py:func:`xray.open_dataset`.
-
-_PyNIO: https://www.pyngl.ucar.edu/Nio.shtml
+- Support for reading GRIB, HDF4 and other file formats via PyNIO_. See
+  :ref:`io.pynio` for more details.
 
 
 v0.6.1 (21 October 2015)

--- a/xray/backends/__init__.py
+++ b/xray/backends/__init__.py
@@ -7,5 +7,6 @@ from .common import AbstractDataStore
 from .memory import InMemoryDataStore
 from .netCDF4_ import NetCDF4DataStore
 from .pydap_ import PydapDataStore
+from .pynio_ import NioDataStore
 from .scipy_ import ScipyDataStore
 from .h5netcdf_ import H5NetCDFStore

--- a/xray/backends/api.py
+++ b/xray/backends/api.py
@@ -117,9 +117,9 @@ def open_dataset(filename_or_obj, group=None, decode_cf=True,
     decode_coords : bool, optional
         If True, decode the 'coordinates' attribute to identify coordinates in
         the resulting dataset.
-    engine : {'netcdf4', 'scipy', 'pydap', 'h5netcdf'}, optional
-        Engine to use when reading netCDF files. If not provided, the default
-        engine is chosen based on available dependencies, with a preference for
+    engine : {'netcdf4', 'scipy', 'pydap', 'h5netcdf', 'pynio'}, optional
+        Engine to use when reading files. If not provided, the default engine
+        is chosen based on available dependencies, with a preference for
         'netcdf4'.
     chunks : int or dict, optional
         If chunks is provided, it used to load the new dataset into dask
@@ -268,9 +268,9 @@ def open_mfdataset(paths, chunks=None, concat_dim=None, preprocess=None,
         want to stack a collection of 2D arrays along a third dimension.
     preprocess : callable, optional
         If provided, call this function on each dataset prior to concatenation.
-    engine : {'netcdf4', 'scipy', 'pydap', 'h5netcdf'}, optional
-        Engine to use when reading netCDF files. If not provided, the default
-        engine is chosen based on available dependencies, with a preference for
+    engine : {'netcdf4', 'scipy', 'pydap', 'h5netcdf', 'pynio'}, optional
+        Engine to use when reading files. If not provided, the default engine
+        is chosen based on available dependencies, with a preference for
         'netcdf4'.
     lock : False, True or threading.Lock, optional
         This argument is passed on to :py:func:`dask.array.from_array`. By

--- a/xray/backends/api.py
+++ b/xray/backends/api.py
@@ -214,6 +214,8 @@ def open_dataset(filename_or_obj, group=None, decode_cf=True,
                 store = backends.PydapDataStore(filename_or_obj)
             elif engine == 'h5netcdf':
                 store = backends.H5NetCDFStore(filename_or_obj, group=group)
+            elif engine == 'pynio':
+                store = backends.NioDataStore(filename_or_obj)
             else:
                 raise ValueError('unrecognized engine for open_dataset: %r'
                                  % engine)

--- a/xray/backends/pynio_.py
+++ b/xray/backends/pynio_.py
@@ -1,0 +1,47 @@
+import numpy as np
+
+from .. import Variable
+from ..core.utils import FrozenOrderedDict, Frozen, NDArrayMixin
+from ..core import indexing
+
+from .common import AbstractDataStore
+
+
+class NioArrayWrapper(NDArrayMixin):
+    def __init__(self, array, ds):
+        self.array = array
+        self._ds = ds  # make an explicit reference because pynio uses weakrefs
+
+    @property
+    def dtype(self):
+        return np.dtype(self.array.typecode())
+
+    def __getitem__(self, key):
+        if key == () and self.ndim == 0:
+            return self.array.get_value()
+        return self.array[key]
+
+
+class NioDataStore(AbstractDataStore):
+    """Store for accessing datasets via PyNIO
+    """
+    def __init__(self, filename, mode='r'):
+        import Nio
+        self.ds = Nio.open_file(filename, mode=mode)
+
+    def open_store_variable(self, var):
+        data = indexing.LazilyIndexedArray(NioArrayWrapper(var, self.ds))
+        return Variable(var.dimensions, data, var.attributes)
+
+    def get_variables(self):
+        return FrozenOrderedDict((k, self.open_store_variable(v))
+                                 for k, v in self.ds.variables.iteritems())
+
+    def get_attrs(self):
+        return Frozen(self.ds.attributes)
+
+    def get_dimensions(self):
+        return Frozen(self.ds.dimensions)
+
+    def close(self):
+        self.ds.close()

--- a/xray/conventions.py
+++ b/xray/conventions.py
@@ -742,8 +742,8 @@ def decode_cf_variable(var, concat_characters=True, mask_and_scale=True,
                                  "xray.conventions.decode_cf(ds)")
             attributes['_FillValue'] = attributes.pop('missing_value')
 
-        fill_value = pop_to(attributes, encoding, '_FillValue')
-        if getattr(fill_value, 'size', 1) > 1:
+        fill_value = np.array(pop_to(attributes, encoding, '_FillValue'))
+        if fill_value.size > 1:
             warnings.warn("variable has multiple fill values {0}, decoding "
                           "all values to NaN.".format(str(fill_value)),
                           RuntimeWarning, stacklevel=3)
@@ -751,7 +751,7 @@ def decode_cf_variable(var, concat_characters=True, mask_and_scale=True,
         add_offset = pop_to(attributes, encoding, 'add_offset')
         if ((fill_value is not None and not np.any(pd.isnull(fill_value))) or
                 scale_factor is not None or add_offset is not None):
-            if isinstance(fill_value, (bytes_type, unicode_type)):
+            if fill_value.dtype.kind in ['U', 'S']:
                 dtype = object
             else:
                 dtype = float

--- a/xray/test/__init__.py
+++ b/xray/test/__init__.py
@@ -41,6 +41,13 @@ except ImportError:
 
 
 try:
+    import Nio
+    has_pynio = True
+except ImportError:
+    has_pynio = False
+
+
+try:
     import dask.array
     import dask
     dask.set_options(get=dask.get)
@@ -70,6 +77,10 @@ def requires_netCDF4(test):
 
 def requires_h5netcdf(test):
     return test if has_h5netcdf else unittest.skip('requires h5netcdf')(test)
+
+
+def requires_pynio(test):
+    return test if has_pynio else unittest.skip('requires pynio')(test)
 
 
 def requires_scipy_or_netCDF4(test):

--- a/xray/test/test_backends.py
+++ b/xray/test/test_backends.py
@@ -21,7 +21,7 @@ from xray.core.pycompat import iteritems, PY3
 
 from . import (TestCase, requires_scipy, requires_netCDF4, requires_pydap,
                requires_scipy_or_netCDF4, requires_dask, requires_h5netcdf,
-               has_netCDF4, has_scipy)
+               requires_pynio, has_netCDF4, has_scipy)
 from .test_dataset import create_test_data
 
 try:
@@ -995,6 +995,36 @@ class PydapTest(TestCase):
     def test_dask(self):
         with self.create_datasets(chunks={'j': 2}) as (actual, expected):
             self.assertDatasetEqual(actual, expected)
+
+
+@requires_scipy
+@requires_pynio
+class TestPyNio(CFEncodedDataTest, Only32BitTypes, TestCase):
+    def test_write_store(self):
+        # pynio is read-only for now
+        pass
+
+    def test_orthogonal_indexing(self):
+        # pynio also does not support list-like indexing
+        pass
+
+    @contextlib.contextmanager
+    def roundtrip(self, data, save_kwargs={}, open_kwargs={}):
+        with create_tmp_file() as tmp_file:
+            data.to_netcdf(tmp_file, engine='scipy', **save_kwargs)
+            with open_dataset(tmp_file, engine='pynio', **open_kwargs) as ds:
+                yield ds
+
+    def test_weakrefs(self):
+        example = Dataset({'foo': ('x', np.arange(5.0))})
+        expected = example.rename({'foo': 'bar', 'x': 'y'})
+
+        with create_tmp_file() as tmp_file:
+            example.to_netcdf(tmp_file, engine='scipy')
+            on_disk = open_dataset(tmp_file, engine='pynio')
+            actual = on_disk.rename({'foo': 'bar', 'x': 'y'})
+            del on_disk  # trigger garbage collection
+            self.assertDatasetIdentical(actual, expected)
 
 
 class TestEncodingInvalid(TestCase):


### PR DESCRIPTION
This pull request adds read-only support for using pynio as an xray backend, by specifying `engine='pydap'` in `open_dataset`.