### PR TITLE
Feature/pytest

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -64,7 +64,7 @@ install:
   - python setup.py install
 
 script:
-  - nosetests --with-coverage --cover-package xray
+  - py.test xray --cov=xray --cov-report term-missing
 
 after_success:
   - coveralls

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -26,10 +26,10 @@ install:
   - "python -c \"import struct; print(struct.calcsize('P') * 8)\""
 
   # install xray and depenencies
-  - "conda install --yes --quiet pip nose numpy pandas scipy netCDF4 matplotlib dask"
+  - "conda install --yes --quiet pip pytest numpy pandas scipy netCDF4 matplotlib dask"
   - "python setup.py install"
 
 build: false
 
 test_script:
-  - "nosetests xray"
+  - "py.test xray"

--- a/ci/requirements-py26.yml
+++ b/ci/requirements-py26.yml
@@ -3,16 +3,19 @@ dependencies:
   - python=2.6.9
   - cython=0.22.1
   - h5py=2.5.0
-  - nose
+  - pytest
   - ordereddict
   - numpy=1.9.2
   - pandas=0.16.2
   - matplotlib=1.4
+  - openssl
+  - toolz
   # no seaborn
   - scipy=0.16.0
   - unittest2
   - pip:
     - coveralls
+    - pytest-cov
     - cyordereddict
     - dask
     - h5netcdf

--- a/ci/requirements-py27-cdat.yml
+++ b/ci/requirements-py27-cdat.yml
@@ -5,10 +5,11 @@ dependencies:
   - python=2.7
   - cdat-lite
   - dask
-  - nose
+  - pytest
   - numpy
   - pandas>=0.15.0
   - scipy
   - pip:
     - coveralls
+    - pytest-cov
     - cyordereddict

--- a/ci/requirements-py27-min.yml
+++ b/ci/requirements-py27-min.yml
@@ -1,8 +1,9 @@
 name: test_env
 dependencies:
   - python=2.7
-  - nose
+  - pytest
   - numpy==1.9.3
   - pandas==0.15.0
   - pip:
     - coveralls
+    - pytest-cov

--- a/ci/requirements-py27-netcdf4-dev.yml
+++ b/ci/requirements-py27-netcdf4-dev.yml
@@ -4,11 +4,12 @@ dependencies:
   - cython
   - dask
   - h5py
-  - nose
+  - pytest
   - numpy
   - pandas
   - scipy
   - pip:
     - coveralls
+    - pytest-cov
     - h5netcdf
     - git+https://github.com/Unidata/netcdf4-python.git

--- a/ci/requirements-py27-pydap.yml
+++ b/ci/requirements-py27-pydap.yml
@@ -4,10 +4,11 @@ dependencies:
   - dask
   - h5py
   - netcdf4
-  - nose
+  - pytest
   - numpy
   - pandas
   - scipy
   - pip:
     - coveralls
+    - pytest-cov
     - pydap

--- a/ci/requirements-py34.yml
+++ b/ci/requirements-py34.yml
@@ -2,7 +2,8 @@ name: test_env
 dependencies:
   - python=3.4
   - bottleneck
-  - nose
+  - pytest
   - pandas
   - pip:
     - coveralls
+    - pytest-cov

--- a/ci/requirements-py35-dask-dev.yml
+++ b/ci/requirements-py35-dask-dev.yml
@@ -2,11 +2,12 @@ name: test_env
 dependencies:
   - python=3.5
   - cython
-  - nose
+  - pytest
   - numpy
   - pandas
   - scipy
   - toolz
   - pip:
     - coveralls
+    - pytest-cov
     - git+https://github.com/blaze/dask.git

--- a/ci/requirements-py35-pandas-dev.yml
+++ b/ci/requirements-py35-pandas-dev.yml
@@ -2,11 +2,13 @@ name: test_env
 dependencies:
   - python=3.5
   - cython=0.23.4
-  - nose
+  - pytest
   - numpy=1.10.1
   - netcdf4=1.1.9
   - scipy=0.16.0
+  - toolz
   - pip:
     - coveralls
+    - pytest-cov
     - dask
     - git+https://github.com/pydata/pandas.git

--- a/ci/requirements-py35.yml
+++ b/ci/requirements-py35.yml
@@ -6,11 +6,12 @@ dependencies:
   - h5py
   - matplotlib
   - netcdf4
-  - nose
+  - pytest
   - numpy
   - pandas
   - seaborn
   - scipy
   - pip:
     - coveralls
+    - pytest-cov
     - h5netcdf

--- a/doc/installing.rst
+++ b/doc/installing.rst
@@ -57,4 +57,4 @@ pandas) installed first. Then, install xray with pip::
     $ pip install xray
 
 To run the test suite after installing xray, install
-`nose <https://nose.readthedocs.org>`__ and run ``nosetests xray``.
+`py.test <https://pytest.org>`__ and run ``py.test xray``.

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,2 +1,5 @@
 [wheel]
 universal = 1
+
+[pytest]
+python_files=test_*.py

--- a/setup.py
+++ b/setup.py
@@ -1,10 +1,11 @@
- #!/usr/bin/env python
+#!/usr/bin/env python
 import os
 import re
 import sys
 import warnings
 
 from setuptools import setup, find_packages
+from setuptools import Command
 
 MAJOR = 0
 MINOR = 6
@@ -36,7 +37,7 @@ CLASSIFIERS = [
 ]
 
 INSTALL_REQUIRES = ['numpy >= 1.7', 'pandas >= 0.15.0']
-TESTS_REQUIRE = ['nose >= 1.0']
+TESTS_REQUIRE = ['pytest >= 2.7.1']
 
 if sys.version_info[:2] < (2, 7):
     TESTS_REQUIRE += ["unittest2 == 0.5.1"]
@@ -132,7 +133,6 @@ short_version = '%s'
 if write_version:
     write_version_py()
 
-
 setup(name=DISTNAME,
       version=FULLVERSION,
       license=LICENSE,
@@ -144,6 +144,5 @@ setup(name=DISTNAME,
       install_requires=INSTALL_REQUIRES,
       tests_require=TESTS_REQUIRE,
       url=URL,
-      test_suite='nose.collector',
       packages=find_packages(),
       package_data={'xray': ['test/data/*', 'plot/default_colormap.csv']})


### PR DESCRIPTION
Uses `py.test` instead of `nosetests` for test collection and execution.

I was mostly curious if this would work given xray's testing structure.  Turns out it does (with one exception in Python 2.6).  I much prefer the traceback that `py.test` returns when tests fail.