### PR TITLE
Rework DataArray internals

### DIFF
--- a/doc/whats-new.rst
+++ b/doc/whats-new.rst
@@ -9,6 +9,64 @@ What's New
     import xray
     np.random.seed(123456)
 
+v0.7.0 (unreleased)
+-------------------
+
+.. _v0.7.0.breaking:
+
+Breaking changes
+~~~~~~~~~~~~~~~~
+
+- The internal data model used by :py:class:`~xray.DataArray` has been
+  rewritten to fix several outstanding issues (:issue:`367`, :issue:`634`,
+  `this stackoverflow report`_). Internally, ``DataArray`` is now implemented
+  in terms of ``._variable`` and ``._coords`` attributes instead of holding
+  variables in a ``Dataset`` object.
+
+  This refactor ensures that if a DataArray has the
+  same name as one of its coordinates, the array and the coordinate no longer
+  share the same data.
+
+  In practice, this means that creating a DataArray with the same ``name`` as
+  one of its dimensions no longer automatically uses that array to label the
+  corresponding coordinate. You will now need to provide coordinate labels
+  explicitly. Here's the old behavior:
+
+  .. ipython::
+    :verbatim:
+
+    In [2]: xray.DataArray([4, 5, 6], dims='x', name='x')
+    Out[2]:
+    <xray.DataArray 'x' (x: 3)>
+    array([4, 5, 6])
+    Coordinates:
+      * x        (x) int64 4 5 6
+
+  and the new behavior (compare the values of the ``x`` coordinate):
+
+  .. ipython::
+    :verbatim:
+
+    In [2]: xray.DataArray([4, 5, 6], dims='x', name='x')
+    Out[2]:
+    <xray.DataArray 'x' (x: 3)>
+    array([4, 5, 6])
+    Coordinates:
+      * x        (x) int64 0 1 2
+
+- It is no longer possible to convert a DataArray to a Dataset with
+  :py:meth:`xray.DataArray.to_dataset` if it is unnamed. This will now
+  raise ``ValueError``. If the array is unnamed, you need to supply the
+  ``name`` argument.
+
+.. _this stackoverflow report: http://stackoverflow.com/questions/33158558/python-xray-extract-first-and-last-time-value-within-each-month-of-a-timeseries
+
+Bug fixes
+~~~~~~~~~
+
+- Fixes for several issues found on ``DataArray`` objects with the same name
+  as one of their coordinates (see :ref:`v0.7.0.breaking` for more details).
+
 v0.6.2 (unreleased)
 -------------------
 

--- a/xray/core/alignment.py
+++ b/xray/core/alignment.py
@@ -100,6 +100,16 @@ def partial_align(*objects, **kwargs):
     return tuple(obj.reindex(copy=copy, **joined_indexes) for obj in objects)
 
 
+def align_variables(variables, join='outer', copy=False):
+    """Align all DataArrays in the provided dict, leaving other values alone.
+    """
+    alignable = [k for k, v in variables.items() if hasattr(v, 'indexes')]
+    aligned = align(*[variables[a] for a in alignable], join=join, copy=copy)
+    new_variables = OrderedDict(variables)
+    new_variables.update(zip(alignable, aligned))
+    return new_variables
+
+
 def reindex_variables(variables, indexes, indexers, method=None,
                       tolerance=None, copy=True):
     """Conform a dictionary of aligned variables onto a new set of variables,

--- a/xray/core/common.py
+++ b/xray/core/common.py
@@ -186,7 +186,7 @@ class BaseDataObject(AttrAccessMixin):
         Dataset.assign
         """
         data = self.copy(deep=False)
-        results = data._calc_assign_results(kwargs)
+        results = self._calc_assign_results(kwargs)
         data.coords.update(results)
         return data
 
@@ -333,7 +333,7 @@ class BaseDataObject(AttrAccessMixin):
         RESAMPLE_DIM = '__resample_dim__'
         if isinstance(dim, basestring):
             dim = self[dim]
-        group = DataArray(dim, name=RESAMPLE_DIM)
+        group = DataArray(dim, [(RESAMPLE_DIM, dim)], name=RESAMPLE_DIM)
         time_grouper = pd.TimeGrouper(freq=freq, how=how, closed=closed,
                                       label=label, base=base)
         gb = self.groupby_cls(self, group, grouper=time_grouper)

--- a/xray/core/merge.py
+++ b/xray/core/merge.py
@@ -1,0 +1,170 @@
+from .alignment import align, partial_align, align_variables
+from .utils import ChainMap
+from .variable import as_variable
+from .pycompat import (basestring, iteritems, OrderedDict)
+
+
+def _as_dataset_variable(name, var):
+    """Prepare a variable for adding it to a Dataset
+    """
+    try:
+        var = as_variable(var, key=name)
+    except TypeError:
+        raise TypeError('variables must be given by arrays or a tuple of '
+                        'the form (dims, data[, attrs, encoding])')
+    if name in var.dims:
+        # convert the into an Index
+        if var.ndim != 1:
+            raise ValueError('the variable %r has the same name as one of its '
+                             'dimensions %r, but it is not 1-dimensional and '
+                             'thus it is not a valid index' % (name, var.dims))
+        var = var.to_coord()
+    return var
+
+
+def expand_variables(raw_variables, old_variables=None, compat='identical'):
+    """Expand a dictionary of variables.
+
+    Returns a dictionary of Variable objects suitable for inserting into a
+    Dataset._variables dictionary.
+
+    This includes converting tuples (dims, data) into Variable objects,
+    converting coordinate variables into Coordinate objects and expanding
+    DataArray objects into Variables plus coordinates.
+
+    Raises ValueError if any conflicting values are found, between any of the
+    new or old variables.
+    """
+    if old_variables is None:
+        old_variables = {}
+    new_variables = OrderedDict()
+    new_coord_names = set()
+    variables = ChainMap(new_variables, old_variables)
+
+    def maybe_promote_or_replace(name, var):
+        existing_var = variables[name]
+        if name not in existing_var.dims:
+            if name in var.dims:
+                variables[name] = var
+            else:
+                common_dims = OrderedDict(zip(existing_var.dims,
+                                              existing_var.shape))
+                common_dims.update(zip(var.dims, var.shape))
+                variables[name] = existing_var.expand_dims(common_dims)
+                new_coord_names.update(var.dims)
+
+    def add_variable(name, var):
+        var = _as_dataset_variable(name, var)
+        if name not in variables:
+            variables[name] = var
+            new_coord_names.update(variables[name].dims)
+        else:
+            if not getattr(variables[name], compat)(var):
+                raise ValueError('conflicting value for variable %s:\n'
+                                 'first value: %r\nsecond value: %r'
+                                 % (name, variables[name], var))
+            if compat == 'broadcast_equals':
+                maybe_promote_or_replace(name, var)
+
+    for name, var in iteritems(raw_variables):
+        if hasattr(var, 'coords'):
+            # it's a DataArray
+            new_coord_names.update(var.coords)
+            for dim, coord in iteritems(var.coords):
+                if dim != name:
+                    add_variable(dim, coord.variable)
+            var = var.variable
+        add_variable(name, var)
+
+    return new_variables, new_coord_names
+
+
+def _merge_expand(variables, other, overwrite_vars, compat):
+    possible_conflicts = dict((k, v) for k, v in variables.items()
+                              if k not in overwrite_vars)
+    new_vars, new_coord_names = expand_variables(other, possible_conflicts, compat)
+    replace_vars = variables.copy()
+    replace_vars.update(new_vars)
+    return replace_vars, new_vars, new_coord_names
+
+
+def _merge_dataset_with_dataset(self, other, overwrite_vars, compat, join):
+    aligned_self, other = align(self, other, join=join, copy=False)
+
+    replace_vars, new_vars, new_coord_names = _merge_expand(
+        aligned_self._variables, other._variables, overwrite_vars, compat)
+    new_coord_names.update(other._coord_names)
+
+    return replace_vars, new_vars, new_coord_names
+
+
+def _merge_dataset_with_dict(self, other, overwrite_vars, compat, join):
+    other = align_variables(other, join='outer', copy=False)
+
+    alignable = [k for k, v in other.items() if hasattr(v, 'indexes')]
+    aligned = partial_align(self, *[other[a] for a in alignable],
+                            join=join, copy=False, exclude=overwrite_vars)
+
+    aligned_self = aligned[0]
+
+    other = OrderedDict(other)
+    other.update(zip(alignable, aligned[1:]))
+
+    return _merge_expand(aligned_self._variables, other, overwrite_vars, compat)
+
+
+def merge_datasets(dataset, other, overwrite_vars=set(),
+                   compat='broadcast_equals', join='outer'):
+    """
+    Guts of Dataset.merge
+    """
+    from .dataset import Dataset
+
+    if compat not in ['broadcast_equals', 'equals', 'identical']:
+        raise ValueError("compat=%r invalid: must be 'broadcast_equals', "
+                         "'equals' or 'identical'" % compat)
+
+    if isinstance(overwrite_vars, basestring):
+        overwrite_vars = [overwrite_vars]
+    overwrite_vars = set(overwrite_vars)
+
+    if isinstance(other, Dataset):
+        merge_func = _merge_dataset_with_dataset
+    else:
+        merge_func = _merge_dataset_with_dict
+
+    replace_vars, new_vars, new_coord_names = merge_func(
+        dataset, other, overwrite_vars, compat=compat, join=join)
+
+    newly_coords = new_coord_names & set(dataset.data_vars)
+    no_longer_coords = set(dataset.coords) & (set(new_vars) - new_coord_names)
+    ambiguous_coords = (newly_coords | no_longer_coords) - overwrite_vars
+    if ambiguous_coords:
+        raise ValueError('cannot merge: the following variables are '
+                         'coordinates on one dataset but not the other: %s'
+                         % list(ambiguous_coords))
+
+    return replace_vars, new_coord_names
+
+
+def _reindex_variables_against(variables, indexes, copy=False):
+    """Reindex all DataArrays in the provided dict, leaving other values alone.
+    """
+    alignable = [k for k, v in variables.items() if hasattr(v, 'indexes')]
+    aligned = [variables[a].reindex(copy=copy, indexes=indexes)
+               for a in alignable]
+    new_variables = OrderedDict(variables)
+    new_variables.update(zip(alignable, aligned))
+    return new_variables
+
+
+def merge_dataarray_coords(indexes, variables, other):
+    """
+    Return the new dictionary of coordinate variables given by merging in
+    ``other`` to to these variables.
+    """
+    other = align_variables(other, join='outer', copy=False)
+    other = _reindex_variables_against(other, indexes, copy=False)
+    replace_vars, _, __ = _merge_expand(
+        variables, other, other, compat='broadcast_equals')
+    return replace_vars

--- a/xray/test/__init__.py
+++ b/xray/test/__init__.py
@@ -195,7 +195,8 @@ class TestCase(unittest.TestCase):
 
     def assertDataArrayIdentical(self, ar1, ar2):
         self.assertEqual(ar1.name, ar2.name)
-        self.assertDatasetIdentical(ar1.to_dataset(), ar2.to_dataset())
+        self.assertDatasetIdentical(ar1._to_temp_dataset(),
+                                    ar2._to_temp_dataset())
 
     def assertDataArrayAllClose(self, ar1, ar2, rtol=1e-05, atol=1e-08):
         self.assertVariableAllClose(ar1, ar2, rtol=rtol, atol=atol)

--- a/xray/test/test_backends.py
+++ b/xray/test/test_backends.py
@@ -121,10 +121,10 @@ class DatasetIOTestCases(object):
             if vars is None:
                 vars = expected
             with self.roundtrip(expected) as actual:
-                for v in actual.values():
+                for v in actual.variables.values():
                     self.assertFalse(v._in_memory)
                 yield actual
-                for k, v in actual.items():
+                for k, v in actual.variables.items():
                     if k in vars:
                         self.assertTrue(v._in_memory)
                 self.assertDatasetAllClose(expected, actual)

--- a/xray/test/test_combine.py
+++ b/xray/test/test_combine.py
@@ -3,7 +3,7 @@ from copy import deepcopy
 import numpy as np
 import pandas as pd
 
-from xray import Dataset, DataArray, auto_combine, concat
+from xray import Dataset, DataArray, auto_combine, concat, Variable
 from xray.core.pycompat import iteritems, OrderedDict
 
 from . import TestCase, InaccessibleArray, requires_dask
@@ -206,6 +206,13 @@ class TestConcatDataset(TestCase):
                 Dataset({'y': ('t', [2])}, {'x': 2})]
         with self.assertRaises(ValueError):
             concat(objs, 't', coords='minimal')
+
+    def test_concat_dim_is_variable(self):
+        objs = [Dataset({'x': 0}), Dataset({'x': 1})]
+        coord = Variable('y', [3, 4])
+        expected = Dataset({'x': ('y', [0, 1]), 'y': [3, 4]})
+        actual = concat(objs, coord)
+        self.assertDatasetIdentical(actual, expected)
 
     @requires_dask  # only for toolz
     def test_auto_combine(self):

--- a/xray/test/test_dask.py
+++ b/xray/test/test_dask.py
@@ -199,7 +199,7 @@ class TestDataArrayAndDataset(DaskTestCase):
 
     def test_new_chunk(self):
         chunked = self.eager_array.chunk()
-        self.assertTrue(chunked.data.name.startswith('xray-foo-'))
+        self.assertTrue(chunked.data.name.startswith('xray-<this-array>'))
 
     def test_lazy_dataset(self):
         lazy_ds = Dataset({'foo': (('x', 'y'), self.data)})

--- a/xray/test/test_plot.py
+++ b/xray/test/test_plot.py
@@ -593,7 +593,7 @@ class Common2dMixin:
         a.coords['d'] = u'foo'
         self.plotfunc(a.isel(c=1))
         title = plt.gca().get_title()
-        self.assertEqual('c = 1, d = foo', title)
+        self.assertTrue('c = 1, d = foo' == title or 'd = foo, c = 1' == title)
 
     def test_colorbar_label(self):
         self.darray.name = 'testvar'

--- a/xray/test/test_variable.py
+++ b/xray/test/test_variable.py
@@ -9,7 +9,7 @@ import pandas as pd
 
 from xray import Variable, Dataset, DataArray
 from xray.core import indexing
-from xray.core.variable import (Coordinate, as_variable, _as_compatible_data)
+from xray.core.variable import (Coordinate, as_variable, as_compatible_data)
 from xray.core.indexing import PandasIndexAdapter, LazilyIndexedArray
 from xray.core.pycompat import PY3, OrderedDict
 
@@ -919,11 +919,11 @@ class TestAsCompatibleData(TestCase):
                          pd.date_range('2000-01-01', periods=3).values]:
                 x = t(data)
                 self.assertIs(source_ndarray(x),
-                              source_ndarray(_as_compatible_data(x)))
+                              source_ndarray(as_compatible_data(x)))
 
     def test_converted_types(self):
         for input_array in [[[0, 1, 2]], pd.DataFrame([[0, 1, 2]])]:
-            actual = _as_compatible_data(input_array)
+            actual = as_compatible_data(input_array)
             self.assertArrayEqual(np.asarray(input_array), actual)
             self.assertEqual(np.ndarray, type(actual))
             self.assertEqual(np.asarray(input_array).dtype, actual.dtype)
@@ -931,39 +931,39 @@ class TestAsCompatibleData(TestCase):
     def test_masked_array(self):
         original = np.ma.MaskedArray(np.arange(5))
         expected = np.arange(5)
-        actual = _as_compatible_data(original)
+        actual = as_compatible_data(original)
         self.assertArrayEqual(expected, actual)
         self.assertEqual(np.dtype(int), actual.dtype)
 
         original = np.ma.MaskedArray(np.arange(5), mask=4 * [False] + [True])
         expected = np.arange(5.0)
         expected[-1] = np.nan
-        actual = _as_compatible_data(original)
+        actual = as_compatible_data(original)
         self.assertArrayEqual(expected, actual)
         self.assertEqual(np.dtype(float), actual.dtype)
 
     def test_datetime(self):
         expected = np.datetime64('2000-01-01T00Z')
-        actual = _as_compatible_data(expected)
+        actual = as_compatible_data(expected)
         self.assertEqual(expected, actual)
         self.assertEqual(np.ndarray, type(actual))
         self.assertEqual(np.dtype('datetime64[ns]'), actual.dtype)
 
         expected = np.array([np.datetime64('2000-01-01T00Z')])
-        actual = _as_compatible_data(expected)
+        actual = as_compatible_data(expected)
         self.assertEqual(np.asarray(expected), actual)
         self.assertEqual(np.ndarray, type(actual))
         self.assertEqual(np.dtype('datetime64[ns]'), actual.dtype)
 
         expected = np.array([np.datetime64('2000-01-01T00Z', 'ns')])
-        actual = _as_compatible_data(expected)
+        actual = as_compatible_data(expected)
         self.assertEqual(np.asarray(expected), actual)
         self.assertEqual(np.ndarray, type(actual))
         self.assertEqual(np.dtype('datetime64[ns]'), actual.dtype)
         self.assertIs(expected, source_ndarray(np.asarray(actual)))
 
         expected = np.datetime64('2000-01-01T00Z', 'ns')
-        actual = _as_compatible_data(datetime(2000, 1, 1))
+        actual = as_compatible_data(datetime(2000, 1, 1))
         self.assertEqual(np.asarray(expected), actual)
         self.assertEqual(np.ndarray, type(actual))
         self.assertEqual(np.dtype('datetime64[ns]'), actual.dtype)


### PR DESCRIPTION
Fixes #367
Fixes #634
Fixes #649

The internal data model used by `DataArray` has been rewritten to fix several outstanding issues (#367, #634 and [this stackoverflow report](http://stackoverflow.com/questions/33158558/python-xray-extract-first-and-last-time-value-within-each-month-of-a-timeseries)). Namely, if a DataArray has the same name as one of its coordinates, the array and the coordinate no longer share the same data.

This means that creating a DataArray with the same ``name`` as one of its dimensions no longer automatically uses that array to label the corresponding coordinate. You will now need to provide coordinate labels explicitly. Here's the old behavior:

    In [2]: xray.DataArray([4, 5, 6], dims='x', name='x')
    Out[2]:
    <xray.DataArray 'x' (x: 3)>
    array([4, 5, 6])
    Coordinates:
      * x        (x) int64 4 5 6

and the new behavior (compare the values of the ``x`` coordinate):

    In [2]: xray.DataArray([4, 5, 6], dims='x', name='x')
    Out[2]:
    <xray.DataArray 'x' (x: 3)>
    array([4, 5, 6])
    Coordinates:
      * x        (x) int64 0 1 2

It's also no longer possible to convert a DataArray to a Dataset with `DataArray.to_dataset` if it is unnamed. This will now raise ``ValueError``. If the array is unnamed, you need to supply the ``name`` argument.