### PR TITLE
Better error message for variables with same name as a dimension

### DIFF
--- a/doc/whats-new.rst
+++ b/doc/whats-new.rst
@@ -17,6 +17,8 @@ Enhancements
 
 - Support for reading GRIB, HDF4 and other file formats via PyNIO_. See
   :ref:`io.pynio` for more details.
+- Better error message when a variable is supplied with the same name as
+  one of its dimensions.
 
 
 v0.6.1 (21 October 2015)

--- a/xray/core/dataset.py
+++ b/xray/core/dataset.py
@@ -72,8 +72,9 @@ def _as_dataset_variable(name, var):
     if name in var.dims:
         # convert the into an Index
         if var.ndim != 1:
-            raise ValueError('an index variable must be defined with '
-                             '1-dimensional data')
+            raise ValueError('the variable %r has the same name as one of its '
+                             'dimensions %r, but it is not 1-dimensional and '
+                             'thus it is not a valid index' % (name, var.dims))
         var = var.to_coord()
     return var
 

--- a/xray/test/test_combine.py
+++ b/xray/test/test_combine.py
@@ -134,7 +134,7 @@ class TestConcatDataset(TestCase):
             data1['dim2'] = 2 * data1['dim2']
             concat([data0, data1], 'dim1', coords='minimal')
 
-        with self.assertRaisesRegexp(ValueError, 'must be defined with 1-d'):
+        with self.assertRaisesRegexp(ValueError, 'it is not 1-dimensional'):
             concat([data0, data1], 'dim1')
 
         with self.assertRaisesRegexp(ValueError, 'compat.* invalid'):

--- a/xray/test/test_dataset.py
+++ b/xray/test/test_dataset.py
@@ -114,7 +114,8 @@ class TestDataset(TestCase):
 
         with self.assertRaisesRegexp(ValueError, 'conflicting sizes'):
             Dataset({'a': x1, 'b': x2})
-        with self.assertRaisesRegexp(ValueError, 'must be defined with 1-d'):
+        with self.assertRaisesRegexp(ValueError,
+                "variable 'x' has the same name"):
             Dataset({'a': x1, 'x': z})
         with self.assertRaisesRegexp(TypeError, 'must be an array or'):
             Dataset({'x': (1, 2, 3, 4, 5, 6, 7)})


### PR DESCRIPTION
We now get:

	In [2]: xray.Dataset({'x': (('x', 'y'), [[1]])})
	ValueError: the variable 'x' has the same name as one of its
	dimensions ('x', 'y'), but it is not 1-dimensional and thus
	it is not a valid index