### PR TITLE
More control on cmap params

### DIFF
--- a/doc/whats-new.rst
+++ b/doc/whats-new.rst
@@ -19,6 +19,9 @@ Enhancements
   :ref:`io.pynio` for more details.
 - Better error message when a variable is supplied with the same name as
   one of its dimensions.
+- Plotting: more control on colormap parameters (:issue:`642`). ``vmin`` and
+  ``vmax`` will not be silently ignored anymore. Setting ``center=False``
+  prevents automatic selection of a divergent colormap.
 
 Bug fixes
 ~~~~~~~~~

--- a/xray/plot/plot.py
+++ b/xray/plot/plot.py
@@ -290,8 +290,10 @@ def _plot2d(plotfunc):
     vmin, vmax : floats, optional
         Values to anchor the colormap, otherwise they are inferred from the
         data and other keyword arguments. When a diverging dataset is inferred,
-        one of these values may be ignored. If discrete levels are provided as
-        an explicit list, both of these values are ignored.
+        setting one of these values will fix the other by symmetry around
+        ``center``. Setting both values prevents use of a diverging colormap.
+        If discrete levels are provided as an explicit list, both of these
+        values are ignored.
     cmap : matplotlib colormap name or object, optional
         The mapping from data values to color space. If not provided, this
         will be either be ``viridis`` (if the function infers a sequential
@@ -304,7 +306,8 @@ def _plot2d(plotfunc):
         or ``contourf``, the ``levels`` argument is required.
     center : float, optional
         The value at which to center the colormap. Passing this value implies
-        use of a diverging colormap.
+        use of a diverging colormap. Setting it to ``False`` prevents use of a
+        diverging colormap.
     robust : bool, optional
         If True and ``vmin`` or ``vmax`` are absent, the colormap range is
         computed with 2nd and 98th percentiles instead of the extreme values.


### PR DESCRIPTION
**Motivation:** https://github.com/xray/xray/issues/642

User's `vmin`, `vmax` are no longer overwritten. You can prevent divergent cmaps and keep automatic vmin, vmax bei setting `center=False`. This is quite intuitive I think (first thing I tried when I wanted to avoid a divergent colormap).

See the new tests for examples of use. 