### PR TITLE
Shift method for shifting data

### DIFF
--- a/doc/api.rst
+++ b/doc/api.rst
@@ -112,6 +112,7 @@ Computation
    Dataset.transpose
    Dataset.diff
    Dataset.shift
+   Dataset.roll
 
 **Aggregation**:
 :py:attr:`~Dataset.all`
@@ -229,6 +230,7 @@ Computation
    DataArray.get_axis_num
    DataArray.diff
    DataArray.shift
+   DataArray.roll
 
 **Aggregation**:
 :py:attr:`~DataArray.all`

--- a/doc/api.rst
+++ b/doc/api.rst
@@ -111,6 +111,7 @@ Computation
    Dataset.resample
    Dataset.transpose
    Dataset.diff
+   Dataset.shift
 
 **Aggregation**:
 :py:attr:`~Dataset.all`
@@ -227,6 +228,7 @@ Computation
    DataArray.transpose
    DataArray.get_axis_num
    DataArray.diff
+   DataArray.shift
 
 **Aggregation**:
 :py:attr:`~DataArray.all`

--- a/doc/whats-new.rst
+++ b/doc/whats-new.rst
@@ -22,6 +22,13 @@ Enhancements
 - Plotting: more control on colormap parameters (:issue:`642`). ``vmin`` and
   ``vmax`` will not be silently ignored anymore. Setting ``center=False``
   prevents automatic selection of a divergent colormap.
+- New :py:meth:`~xray.Dataset.shift` method for shifting datasets or arrays
+  along a dimension:
+
+  .. ipython:: python
+
+      array = xray.DataArray([5, 6, 7, 8], dims='x')
+      array.shift(x=2)
 
 Bug fixes
 ~~~~~~~~~

--- a/doc/whats-new.rst
+++ b/doc/whats-new.rst
@@ -22,13 +22,17 @@ Enhancements
 - Plotting: more control on colormap parameters (:issue:`642`). ``vmin`` and
   ``vmax`` will not be silently ignored anymore. Setting ``center=False``
   prevents automatic selection of a divergent colormap.
-- New :py:meth:`~xray.Dataset.shift` method for shifting datasets or arrays
-  along a dimension:
+- New :py:meth:`~xray.Dataset.shift` and :py:meth:`~xray.Dataset.roll` methods
+  for shifting/rotating datasets or arrays along a dimension:
 
   .. ipython:: python
 
       array = xray.DataArray([5, 6, 7, 8], dims='x')
       array.shift(x=2)
+      array.roll(x=2)
+
+  Notice that ``shift`` moves data independently of coordinates, but ``roll``
+  moves both data and coordinates.
 
 Bug fixes
 ~~~~~~~~~

--- a/xray/core/dataarray.py
+++ b/xray/core/dataarray.py
@@ -1222,6 +1222,35 @@ class DataArray(AbstractArray, BaseDataObject):
         ds[self.name] = self.variable.shift(**shifts)
         return self._with_replaced_dataset(ds)
 
+    def roll(self, **shifts):
+        """Roll this array by an offset along one or more dimensions.
+
+        Unlike shift, roll rotates all variables, including coordinates.
+
+        Parameters
+        ----------
+        **shifts : keyword arguments of the form {dim: offset}
+            Integer offset to rotate each of the given dimensions. Positive
+            offsets roll to the right; negative offsets roll to the left.
+
+        Returns
+        -------
+        shifted : DataArray
+            DataArray with the same attributes but rolled data and coordinates.
+
+        Examples
+        --------
+
+        >>> arr = xray.DataArray([5, 6, 7], dims='x')
+        >>> arr.roll(x=1)
+        <xray.DataArray (x: 3)>
+        array([7, 5, 6])
+        Coordinates:
+          * x        (x) int64 2 0 1
+        """
+        ds = self._dataset.roll(**shifts)
+        return self._with_replaced_dataset(ds)
+
     @property
     def real(self):
         return self._with_replaced_dataset(self._dataset.real)

--- a/xray/core/dataarray.py
+++ b/xray/core/dataarray.py
@@ -1189,6 +1189,39 @@ class DataArray(AbstractArray, BaseDataObject):
         ds = self._dataset.diff(n=n, dim=dim, label=label)
         return self._with_replaced_dataset(ds)
 
+    def shift(self, **shifts):
+        """Shift this array by an offset along one or more dimensions.
+
+        Only the data is moved; coordinates stay in place. Values shifted from
+        beyond array bounds are replaced by NaN.
+
+        Parameters
+        ----------
+        **shifts : keyword arguments of the form {dim: offset}
+            Integer offset to shift along each of the given dimensions.
+            Positive offsets shift to the right; negative offsets shift to the
+            left.
+
+        Returns
+        -------
+        shifted : DataArray
+            DataArray with the same coordinates and attributes but shifted
+            data.
+
+        Examples
+        --------
+
+        >>> arr = xray.DataArray([5, 6, 7], dims='x')
+        >>> arr.shift(x=1)
+        <xray.DataArray (x: 3)>
+        array([ nan,   5.,   6.])
+        Coordinates:
+          * x        (x) int64 0 1 2
+        """
+        ds = self._dataset.copy()
+        ds[self.name] = self.variable.shift(**shifts)
+        return self._with_replaced_dataset(ds)
+
     @property
     def real(self):
         return self._with_replaced_dataset(self._dataset.real)

--- a/xray/core/dataarray.py
+++ b/xray/core/dataarray.py
@@ -1193,7 +1193,8 @@ class DataArray(AbstractArray, BaseDataObject):
         """Shift this array by an offset along one or more dimensions.
 
         Only the data is moved; coordinates stay in place. Values shifted from
-        beyond array bounds are replaced by NaN.
+        beyond array bounds are replaced by NaN. This is consistent with the
+        behavior of ``shift`` in pandas.
 
         Parameters
         ----------
@@ -1207,6 +1208,10 @@ class DataArray(AbstractArray, BaseDataObject):
         shifted : DataArray
             DataArray with the same coordinates and attributes but shifted
             data.
+
+        See also
+        --------
+        roll
 
         Examples
         --------
@@ -1225,7 +1230,8 @@ class DataArray(AbstractArray, BaseDataObject):
     def roll(self, **shifts):
         """Roll this array by an offset along one or more dimensions.
 
-        Unlike shift, roll rotates all variables, including coordinates.
+        Unlike shift, roll rotates all variables, including coordinates. The
+        direction of rotation is consistent with :py:func:`numpy.roll`.
 
         Parameters
         ----------
@@ -1235,8 +1241,12 @@ class DataArray(AbstractArray, BaseDataObject):
 
         Returns
         -------
-        shifted : DataArray
+        rolled : DataArray
             DataArray with the same attributes but rolled data and coordinates.
+
+        See also
+        --------
+        shift
 
         Examples
         --------

--- a/xray/core/dataset.py
+++ b/xray/core/dataset.py
@@ -2084,8 +2084,8 @@ class Dataset(Mapping, ImplementsDatasetReduce, BaseDataObject):
     def shift(self, **shifts):
         """Shift this dataset by an offset along one or more dimensions.
 
-        Only data variables are moved; coordinates stay in place. Values
-        shifted from bounds beyond dataset bounds are replaced by NaN.
+        Only data variables are moved; coordinates stay in place. This is
+        consistent with the behavior of ``shift`` in pandas.
 
         Parameters
         ----------
@@ -2134,14 +2134,14 @@ class Dataset(Mapping, ImplementsDatasetReduce, BaseDataObject):
     def roll(self, **shifts):
         """Roll this dataset by an offset along one or more dimensions.
 
-        Unlike shift, roll shifts all variables, including coordinates.
+        Unlike shift, roll rotates all variables, including coordinates. The
+        direction of rotation is consistent with :py:func:`numpy.roll`.
 
         Parameters
         ----------
         **shifts : keyword arguments of the form {dim: offset}
-            Integer offset to roll along each of the given dimensions.
-            Positive offsets roll to the right; negative offsets roll to the
-            left.
+            Integer offset to rotate each of the given dimensions. Positive
+            offsets roll to the right; negative offsets roll to the left.
 
         Returns
         -------

--- a/xray/core/variable.py
+++ b/xray/core/variable.py
@@ -508,7 +508,7 @@ class Variable(common.AbstractArray, utils.NdimSizeLenMixin):
         elif count < 0:
             keep = slice(-count, None)
         else:
-            return self
+            keep = slice(None)
 
         trimmed_data = self[(slice(None),) * axis + (keep,)].data
         dtype, fill_value = common._maybe_promote(self.dtype)
@@ -535,6 +535,7 @@ class Variable(common.AbstractArray, utils.NdimSizeLenMixin):
         if isinstance(data, dask_array_type):
             # chunked data should come out with the same chunks; this makes
             # it feasible to combine shifted and unshifted data
+            # TODO: remove this once dask.array automatically aligns chunks
             data = data.rechunk(self.data.chunks)
 
         return type(self)(self.dims, data, self._attrs, fastpath=True)
@@ -558,6 +559,49 @@ class Variable(common.AbstractArray, utils.NdimSizeLenMixin):
         result = self
         for dim, count in shifts.items():
             result = result._shift_one_dim(dim, count)
+        return result
+
+    def _roll_one_dim(self, dim, count):
+        axis = self.get_axis_num(dim)
+
+        count %= self.shape[axis]
+        if count != 0:
+            indices = [slice(-count, None), slice(None, -count)]
+        else:
+            indices = [slice(None)]
+
+        arrays = [self[(slice(None),) * axis + (idx,)].data
+                  for idx in indices]
+
+        data = ops.concatenate(arrays, axis)
+
+        if isinstance(data, dask_array_type):
+            # chunked data should come out with the same chunks; this makes
+            # it feasible to combine shifted and unshifted data
+            # TODO: remove this once dask.array automatically aligns chunks
+            data = data.rechunk(self.data.chunks)
+
+        return type(self)(self.dims, data, self._attrs, fastpath=True)
+
+    def roll(self, **shifts):
+        """
+        Return a new Variable with rolld data.
+
+        Parameters
+        ----------
+        **shifts : keyword arguments of the form {dim: offset}
+            Integer offset to roll along each of the given dimensions.
+            Positive offsets roll to the right; negative offsets roll to the
+            left.
+
+        Returns
+        -------
+        shifted : Variable
+            Variable with the same dimensions and attributes but rolled data.
+        """
+        result = self
+        for dim, count in shifts.items():
+            result = result._roll_one_dim(dim, count)
         return result
 
     def transpose(self, *dims):

--- a/xray/core/variable.py
+++ b/xray/core/variable.py
@@ -532,6 +532,11 @@ class Variable(common.AbstractArray, utils.NdimSizeLenMixin):
 
         data = ops.concatenate(arrays, axis)
 
+        if isinstance(data, dask_array_type):
+            # chunked data should come out with the same chunks; this makes
+            # it feasible to combine shifted and unshifted data
+            data = data.rechunk(self.data.chunks)
+
         return type(self)(self.dims, data, self._attrs, fastpath=True)
 
     def shift(self, **shifts):

--- a/xray/core/variable.py
+++ b/xray/core/variable.py
@@ -15,6 +15,11 @@ from .indexing import (PandasIndexAdapter, orthogonally_indexable)
 
 import xray  # only for Dataset and DataArray
 
+try:
+    import dask.array as da
+except ImportError:
+    pass
+
 
 def as_variable(obj, key=None, strict=True):
     """Convert an object into an Variable
@@ -494,6 +499,61 @@ class Variable(common.AbstractArray, utils.NdimSizeLenMixin):
             if dim in indexers:
                 key[i] = indexers[dim]
         return self[tuple(key)]
+
+    def _shift_one_dim(self, dim, count):
+        axis = self.get_axis_num(dim)
+
+        if count > 0:
+            keep = slice(None, -count)
+        elif count < 0:
+            keep = slice(-count, None)
+        else:
+            return self
+
+        trimmed_data = self[(slice(None),) * axis + (keep,)].data
+        dtype, fill_value = common._maybe_promote(self.dtype)
+
+        shape = list(self.shape)
+        shape[axis] = min(abs(count), shape[axis])
+
+        if isinstance(trimmed_data, dask_array_type):
+            chunks = list(trimmed_data.chunks)
+            chunks[axis] = (shape[axis],)
+            full = functools.partial(da.full, chunks=chunks)
+        else:
+            full = np.full
+
+        nans = full(shape, fill_value, dtype=dtype)
+
+        if count > 0:
+            arrays = [nans, trimmed_data]
+        else:
+            arrays = [trimmed_data, nans]
+
+        data = ops.concatenate(arrays, axis)
+
+        return type(self)(self.dims, data, self._attrs, fastpath=True)
+
+    def shift(self, **shifts):
+        """
+        Return a new Variable with shifted data.
+
+        Parameters
+        ----------
+        **shifts : keyword arguments of the form {dim: offset}
+            Integer offset to shift along each of the given dimensions.
+            Positive offsets shift to the right; negative offsets shift to the
+            left.
+
+        Returns
+        -------
+        shifted : Variable
+            Variable with the same dimensions and attributes but shifted data.
+        """
+        result = self
+        for dim, count in shifts.items():
+            result = result._shift_one_dim(dim, count)
+        return result
 
     def transpose(self, *dims):
         """Return a new Variable object with transposed dimensions.

--- a/xray/test/test_dask.py
+++ b/xray/test/test_dask.py
@@ -111,6 +111,12 @@ class TestVariable(DaskTestCase):
         self.assertLazyAndIdentical(u.shift(x=-2), v.shift(x=-2))
         self.assertEqual(v.data.chunks, v.shift(x=1).data.chunks)
 
+    def test_roll(self):
+        u = self.eager_var
+        v = self.lazy_var
+        self.assertLazyAndIdentical(u.roll(x=2), v.roll(x=2))
+        self.assertEqual(v.data.chunks, v.roll(x=1).data.chunks)
+
     def test_unary_op(self):
         u = self.eager_var
         v = self.lazy_var

--- a/xray/test/test_dask.py
+++ b/xray/test/test_dask.py
@@ -104,6 +104,12 @@ class TestVariable(DaskTestCase):
         v = self.lazy_var
         self.assertLazyAndIdentical(u.T, v.T)
 
+    def test_shift(self):
+        u = self.eager_var
+        v = self.lazy_var
+        self.assertLazyAndIdentical(u.shift(x=2), v.shift(x=2))
+        self.assertLazyAndIdentical(u.shift(x=-2), v.shift(x=-2))
+
     def test_unary_op(self):
         u = self.eager_var
         v = self.lazy_var

--- a/xray/test/test_dask.py
+++ b/xray/test/test_dask.py
@@ -109,6 +109,7 @@ class TestVariable(DaskTestCase):
         v = self.lazy_var
         self.assertLazyAndIdentical(u.shift(x=2), v.shift(x=2))
         self.assertLazyAndIdentical(u.shift(x=-2), v.shift(x=-2))
+        self.assertEqual(v.data.chunks, v.shift(x=1).data.chunks)
 
     def test_unary_op(self):
         u = self.eager_var

--- a/xray/test/test_dataarray.py
+++ b/xray/test/test_dataarray.py
@@ -1478,6 +1478,12 @@ class TestDataArray(TestCase):
             actual = arr.shift(x=offset)
             self.assertDataArrayIdentical(expected, actual)
 
+    def test_roll(self):
+        arr = DataArray([1, 2, 3], dims='x')
+        actual = arr.roll(x=1)
+        expected = DataArray([3, 1, 2], coords=[('x', [2, 0, 1])])
+        self.assertDataArrayIdentical(expected, actual)
+
     def test_real_and_imag(self):
         array = DataArray(1 + 2j)
         self.assertDataArrayIdentical(array.real, DataArray(1))

--- a/xray/test/test_dataarray.py
+++ b/xray/test/test_dataarray.py
@@ -1467,6 +1467,17 @@ class TestDataArray(TestCase):
                              ['x', 'y'])
         self.assertDataArrayEqual(expected, actual)
 
+    def test_shift(self):
+        arr = DataArray([1, 2, 3], dims='x')
+        actual = arr.shift(x=1)
+        expected = DataArray([np.nan, 1, 2], dims='x')
+        self.assertDataArrayIdentical(expected, actual)
+
+        for offset in [-5, -2, -1, 0, 1, 2, 5]:
+            expected = DataArray(arr.to_pandas().shift(offset))
+            actual = arr.shift(x=offset)
+            self.assertDataArrayIdentical(expected, actual)
+
     def test_real_and_imag(self):
         array = DataArray(1 + 2j)
         self.assertDataArrayIdentical(array.real, DataArray(1))

--- a/xray/test/test_dataset.py
+++ b/xray/test/test_dataset.py
@@ -2162,6 +2162,17 @@ class TestDataset(TestCase):
         with self.assertRaisesRegexp(ValueError, '\'label\' argument has to'):
             ds.diff('dim2', label='raise_me')
 
+    def test_shift(self):
+        coords = {'bar': ('x', list('abc')), 'x': [-4, 3, 2]}
+        attrs = {'meta': 'data'}
+        ds = Dataset({'foo': ('x', [1, 2, 3])}, coords, attrs)
+        actual = ds.shift(x=1)
+        expected = Dataset({'foo': ('x', [np.nan, 1, 2])}, coords, attrs)
+        self.assertDatasetIdentical(expected, actual)
+
+        with self.assertRaisesRegexp(ValueError, 'dimensions'):
+            ds.shift(foo=123)
+
     def test_real_and_imag(self):
         attrs = {'foo': 'bar'}
         ds = Dataset({'x': ((), 1 + 2j, attrs)}, attrs=attrs)

--- a/xray/test/test_dataset.py
+++ b/xray/test/test_dataset.py
@@ -2173,6 +2173,19 @@ class TestDataset(TestCase):
         with self.assertRaisesRegexp(ValueError, 'dimensions'):
             ds.shift(foo=123)
 
+    def test_roll(self):
+        coords = {'bar': ('x', list('abc')), 'x': [-4, 3, 2]}
+        attrs = {'meta': 'data'}
+        ds = Dataset({'foo': ('x', [1, 2, 3])}, coords, attrs)
+        actual = ds.roll(x=1)
+
+        ex_coords = {'bar': ('x', list('cab')), 'x': [2, -4, 3]}
+        expected = Dataset({'foo': ('x', [3, 1, 2])}, ex_coords, attrs)
+        self.assertDatasetIdentical(expected, actual)
+
+        with self.assertRaisesRegexp(ValueError, 'dimensions'):
+            ds.roll(foo=123)
+
     def test_real_and_imag(self):
         attrs = {'foo': 'bar'}
         ds = Dataset({'x': ((), 1 + 2j, attrs)}, attrs=attrs)

--- a/xray/test/test_variable.py
+++ b/xray/test/test_variable.py
@@ -629,6 +629,7 @@ class TestVariable(TestCase, VariableSubclassTestCases):
         v = Variable('x', [1, 2, 3, 4, 5])
 
         self.assertVariableIdentical(v, v.shift(x=0))
+        self.assertIsNot(v, v.shift(x=0))
 
         expected = Variable('x', [np.nan, 1, 2, 3, 4])
         self.assertVariableIdentical(expected, v.shift(x=1))
@@ -656,6 +657,33 @@ class TestVariable(TestCase, VariableSubclassTestCases):
         v = Variable(('x', 'y'), [[1, 2], [3, 4]])
         expected = Variable(('x', 'y'), [[np.nan, np.nan], [np.nan, 1]])
         self.assertVariableIdentical(expected, v.shift(x=1, y=1))
+
+    def test_roll(self):
+        v = Variable('x', [1, 2, 3, 4, 5])
+
+        self.assertVariableIdentical(v, v.roll(x=0))
+        self.assertIsNot(v, v.roll(x=0))
+
+        expected = Variable('x', [5, 1, 2, 3, 4])
+        self.assertVariableIdentical(expected, v.roll(x=1))
+        self.assertVariableIdentical(expected, v.roll(x=-4))
+        self.assertVariableIdentical(expected, v.roll(x=6))
+
+        expected = Variable('x', [4, 5, 1, 2, 3])
+        self.assertVariableIdentical(expected, v.roll(x=2))
+        self.assertVariableIdentical(expected, v.roll(x=-3))
+
+        with self.assertRaisesRegexp(ValueError, 'dimension'):
+            v.roll(z=0)
+
+    def test_roll_consistency(self):
+        v = Variable(('x', 'y'), np.random.randn(5, 6))
+
+        for axis, dim in [(0, 'x'), (1, 'y')]:
+            for shift in [-3, 0, 1, 7, 11]:
+                expected = np.roll(v.values, shift, axis=axis)
+                actual = v.roll(**{dim: shift}).values
+                self.assertArrayEqual(expected, actual)
 
     def test_transpose(self):
         v = Variable(['time', 'x'], self.d)

--- a/xray/test/test_variable.py
+++ b/xray/test/test_variable.py
@@ -625,6 +625,38 @@ class TestVariable(TestCase, VariableSubclassTestCases):
         expected = Variable((), u'tmax')
         self.assertVariableIdentical(actual, expected)
 
+    def test_shift(self):
+        v = Variable('x', [1, 2, 3, 4, 5])
+
+        self.assertVariableIdentical(v, v.shift(x=0))
+
+        expected = Variable('x', [np.nan, 1, 2, 3, 4])
+        self.assertVariableIdentical(expected, v.shift(x=1))
+
+        expected = Variable('x', [np.nan, np.nan, 1, 2, 3])
+        self.assertVariableIdentical(expected, v.shift(x=2))
+
+        expected = Variable('x', [2, 3, 4, 5, np.nan])
+        self.assertVariableIdentical(expected, v.shift(x=-1))
+
+        expected = Variable('x', [np.nan] * 5)
+        self.assertVariableIdentical(expected, v.shift(x=5))
+        self.assertVariableIdentical(expected, v.shift(x=6))
+
+        with self.assertRaisesRegexp(ValueError, 'dimension'):
+            v.shift(z=0)
+
+        v = Variable('x', [1, 2, 3, 4, 5], {'foo': 'bar'})
+        self.assertVariableIdentical(v, v.shift(x=0))
+
+        expected = Variable('x', [np.nan, 1, 2, 3, 4], {'foo': 'bar'})
+        self.assertVariableIdentical(expected, v.shift(x=1))
+
+    def test_shift2d(self):
+        v = Variable(('x', 'y'), [[1, 2], [3, 4]])
+        expected = Variable(('x', 'y'), [[np.nan, np.nan], [np.nan, 1]])
+        self.assertVariableIdentical(expected, v.shift(x=1, y=1))
+
     def test_transpose(self):
         v = Variable(['time', 'x'], self.d)
         v2 = Variable(['x', 'time'], self.d.T)


### PR DESCRIPTION
Fixes #624

New `shift` method for shifting datasets or arrays along a dimension:

     In [1]: import xray

     In [2]: array = xray.DataArray([5, 6, 7, 8], dims='x')

     In [3]: array.shift(x=2)
     Out[3]:
     <xray.DataArray (x: 4)>
     array([ nan,  nan,   5.,   6.])
     Coordinates:
       * x        (x) int64 0 1 2 3

Based on the API proposed for `roll` in https://github.com/xray/xray/issues/624