### PR TITLE
Fix resample docstring

### DIFF
--- a/xray/core/common.py
+++ b/xray/core/common.py
@@ -289,7 +289,7 @@ class BaseDataObject(AttrAccessMixin):
             of valid offsets include:
 
             * 'AS': year start
-            * 'Q-DEC': quarter, starting on December 1
+            * 'QS-DEC': quarterly, starting on December 1
             * 'MS': month start
             * 'D': day
             * 'H': hour


### PR DESCRIPTION
To use the start of a quarter, we actually need to label things like QS.