### PR TITLE
Add broadcast function to the API

### DIFF
--- a/doc/api.rst
+++ b/doc/api.rst
@@ -15,6 +15,7 @@ Top-level functions
    :toctree: generated/
 
    align
+   broadcast
    concat
    set_options
 

--- a/doc/whats-new.rst
+++ b/doc/whats-new.rst
@@ -67,7 +67,7 @@ Bug fixes
 - Fixes for several issues found on ``DataArray`` objects with the same name
   as one of their coordinates (see :ref:`v0.7.0.breaking` for more details).
 
-- ``DataArray.to_masked_array`` always returns masked array with mask being an array 
+- ``DataArray.to_masked_array`` always returns masked array with mask being an array
 (not a scalar value) (:issue:`684`)
 
 v0.6.2 (unreleased)
@@ -96,6 +96,18 @@ Enhancements
   moves both data and coordinates.
 - Assigning a ``pandas`` object to a ``Dataset`` directly is now permitted. Its
   index names correspond to the `dims`` of the ``Dataset``, and its data is aligned
+- New function :py:func:`~xray.broadcast` for explicitly broadcasting
+  ``DataArray`` and ``Dataset`` objects against each other. For example:
+
+  .. ipython:: python
+
+      a = xray.DataArray([1, 2, 3], dims='x')
+      b = xray.DataArray([5, 6], dims='y')
+      a
+      b
+      a2, b2 = xray.broadcast(a, b)
+      a2
+      b2
 
 Bug fixes
 ~~~~~~~~~

--- a/xray/__init__.py
+++ b/xray/__init__.py
@@ -1,4 +1,4 @@
-from .core.alignment import align, broadcast_arrays
+from .core.alignment import align, broadcast, broadcast_arrays
 from .core.combine import concat, auto_combine
 from .core.variable import Variable, Coordinate
 from .core.dataset import Dataset


### PR DESCRIPTION
This is a renaming and update of the existing `xray.broadcast_arrays` function,
which now works properly in the light of #648.

xref #649
cc @rabernat 

Examples
--------

Broadcast two data arrays against one another to fill out their dimensions:

    >>> a = xray.DataArray([1, 2, 3], dims='x')
    >>> b = xray.DataArray([5, 6], dims='y')
    >>> a
    <xray.DataArray (x: 3)>
    array([1, 2, 3])
    Coordinates:
      * x        (x) int64 0 1 2
    >>> b
    <xray.DataArray (y: 2)>
    array([5, 6])
    Coordinates:
      * y        (y) int64 0 1
    >>> a2, b2 = xray.broadcast(a, b)
    >>> a2
    <xray.DataArray (x: 3, y: 2)>
    array([[1, 1],
           [2, 2],
           [3, 3]])
    Coordinates:
      * x        (x) int64 0 1 2
      * y        (y) int64 0 1
    >>> b2
    <xray.DataArray (x: 3, y: 2)>
    array([[5, 6],
           [5, 6],
           [5, 6]])
    Coordinates:
      * y        (y) int64 0 1
      * x        (x) int64 0 1 2

Fill out the dimensions of all data variables in a dataset:

    >>> ds = xray.Dataset({'a': a, 'b': b})
    >>> ds2, = xray.broadcast(ds)  # use tuple unpacking to extract one dataset
    >>> ds2
    <xray.Dataset>
    Dimensions:  (x: 3, y: 2)
    Coordinates:
      * x        (x) int64 0 1 2
      * y        (y) int64 0 1
    Data variables:
        a        (x, y) int64 1 1 2 2 3 3
        b        (x, y) int64 5 6 5 6 5 6