### PR TITLE
Fix a bug in alignment when assigning to DataArray.coords

### DIFF
--- a/xray/core/merge.py
+++ b/xray/core/merge.py
@@ -151,7 +151,7 @@ def _reindex_variables_against(variables, indexes, copy=False):
     """Reindex all DataArrays in the provided dict, leaving other values alone.
     """
     alignable = [k for k, v in variables.items() if hasattr(v, 'indexes')]
-    aligned = [variables[a].reindex(copy=copy, indexes=indexes)
+    aligned = [variables[a].reindex(copy=copy, **indexes)
                for a in alignable]
     new_variables = OrderedDict(variables)
     new_variables.update(zip(alignable, aligned))

--- a/xray/test/test_dataarray.py
+++ b/xray/test/test_dataarray.py
@@ -603,6 +603,15 @@ class TestDataArray(TestCase):
         expected.coords['d'] = ('x', [1.5, 1.5, 3.5, 3.5])
         self.assertDataArrayIdentical(actual, expected)
 
+    def test_coords_alignment(self):
+        lhs = DataArray([1, 2, 3], [('x', [0, 1, 2])])
+        rhs = DataArray([2, 3, 4], [('x', [1, 2, 3])])
+        lhs.coords['rhs'] = rhs
+
+        expected = DataArray([1, 2, 3], coords={'rhs': ('x', [np.nan, 2, 3])},
+                             dims='x')
+        self.assertDataArrayIdentical(lhs, expected)
+
     def test_reindex(self):
         foo = self.dv
         bar = self.dv[:2, :2]


### PR DESCRIPTION
I noticed that the doc build was broken.

This was introduced by #648, so it hasn't appeared in a released version yet.